### PR TITLE
reservoir min storage and reservoir parquet file migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,12 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+mosartwmpy/grand_average_monthly_demand_20230404.parquet
+mosartwmpy/grand_average_monthly_flow_20230404.parquet
+mosartwmpy/grand_dependency_database_20230404.parquet
+mosartwmpy/grand_reservoir_parameters_20230404.nc
+mosartwmpy/input/domains/land.nc
+mosartwmpy/input/domains/mosart.nc
+mosartwmpy/input/domains/mosart_conus_nldas_grid.nc
+environment.yml
+Untitled.ipynb

--- a/mosartwmpy/config/config.py
+++ b/mosartwmpy/config/config.py
@@ -1,10 +1,10 @@
-import pkg_resources
+import importlib.resources
 from benedict import benedict
 from benedict.dicts import benedict as Benedict
 
 
 def get_config(config_file_path: str = None) -> Benedict:
-    """Configuration object for the model, using the Benedict type.
+    """Loads and merges configuration files into a Benedict object.
     
     Args:
         config_file_path (string): path to the user defined configuration yaml file
@@ -12,8 +12,12 @@ def get_config(config_file_path: str = None) -> Benedict:
     Returns:
         Benedict: A Benedict instance containing the merged configuration
     """
-    config = benedict(pkg_resources.resource_filename('mosartwmpy', 'config_defaults.yaml'), format='yaml')
+    with importlib.resources.path('mosartwmpy', 'config_defaults.yaml') as config_defaults_path:
+        config = benedict(str(config_defaults_path), format='yaml')
     if config_file_path is not None and config_file_path != '':
+        if not isinstance(config_file_path, str):
+            config_file_path = str(config_file_path)
+        config.merge(benedict(config_file_path, format='yaml'), overwrite=True)
         config.merge(benedict(str(config_file_path), format='yaml'), overwrite=True)
     
     return config

--- a/mosartwmpy/config/parameters.py
+++ b/mosartwmpy/config/parameters.py
@@ -42,7 +42,7 @@ class Parameters:
         self.reservoir_flood_control_condition = 1.0
         self.reservoir_small_magnitude_difference = 0.01
         self.reservoir_regulation_release_parameter = 0.85
-        self.reservoir_runoff_capacity_parameter = 0.1
+        self.reservoir_runoff_capacity_parameter = 0.1 # fraction of capacity to set minimum storage
         self.reservoir_flow_volume_ratio = 0.9
         
         # number of supply iterations

--- a/mosartwmpy/config_defaults.yaml
+++ b/mosartwmpy/config_defaults.yaml
@@ -251,6 +251,8 @@ water_management:
                 reservoir_surface_area: AREA_SKM
                 # storage capacity field name [million m3]
                 reservoir_storage_capacity: CAP_MCM
+                # minimum storage capacity field name [million m3]
+                reservoir_storage_minimum: CAP_MIN
                 # depth field name [m]
                 reservoir_depth: DEPTH_M
                 # use irrigation field name

--- a/mosartwmpy/model.py
+++ b/mosartwmpy/model.py
@@ -130,9 +130,9 @@ class Model(Bmi):
                     else:
                         logging.warning('Unable to parse date from restart file name, falling back to configured start date.')
                         self.current_time = datetime.combine(self.config.get('simulation.start_date'), time.min)
-                    x = xr.open_dataset(path)
-                    self.state = State.from_dataframe(x.to_dataframe())
-                    x.close()
+                    ds = xr.open_dataset(path)
+                    self.state = State.from_dataframe(ds.to_dataframe())
+                    ds.close()
                 else:
                     # simulation start time
                     self.current_time = datetime.combine(self.config.get('simulation.start_date'), time.min)

--- a/mosartwmpy/reservoirs/grid.py
+++ b/mosartwmpy/reservoirs/grid.py
@@ -19,7 +19,6 @@ def load_reservoirs(self, config: Benedict, parameters: Parameters) -> None:
     """
 
     # reservoir parameter file
-    # reservoirs_file = open_dataset(config.get('water_management.reservoirs.parameters.path'))
     reservoirs_file = pd.read_parquet(config.get('water_management.reservoirs.parameters.path'))
     reservoirs = pd.DataFrame(index=self.id).merge(
         reservoirs_file,
@@ -27,14 +26,6 @@ def load_reservoirs(self, config: Benedict, parameters: Parameters) -> None:
         left_index=True,
         right_on=config.get('water_management.reservoirs.parameters.grid_cell_index'),
     )
-
-    # reservoirs = pd.DataFrame(index=self.id).merge(
-    #     reservoirs_file.to_dataframe(),
-    #     how='left',
-    #     left_index=True,
-    #     right_on=config.get('water_management.reservoirs.parameters.grid_cell_index'),
-    # )
-    # reservoirs_file.close()
 
     # load reservoir variables
     for key, value in config.get('water_management.reservoirs.parameters.variables').items():

--- a/mosartwmpy/reservoirs/grid.py
+++ b/mosartwmpy/reservoirs/grid.py
@@ -19,14 +19,22 @@ def load_reservoirs(self, config: Benedict, parameters: Parameters) -> None:
     """
 
     # reservoir parameter file
-    reservoirs_file = open_dataset(config.get('water_management.reservoirs.parameters.path'))
+    # reservoirs_file = open_dataset(config.get('water_management.reservoirs.parameters.path'))
+    reservoirs_file = pd.read_parquet(config.get('water_management.reservoirs.parameters.path'))
     reservoirs = pd.DataFrame(index=self.id).merge(
-        reservoirs_file.to_dataframe(),
+        reservoirs_file,
         how='left',
         left_index=True,
         right_on=config.get('water_management.reservoirs.parameters.grid_cell_index'),
     )
-    reservoirs_file.close()
+
+    # reservoirs = pd.DataFrame(index=self.id).merge(
+    #     reservoirs_file.to_dataframe(),
+    #     how='left',
+    #     left_index=True,
+    #     right_on=config.get('water_management.reservoirs.parameters.grid_cell_index'),
+    # )
+    # reservoirs_file.close()
 
     # load reservoir variables
     for key, value in config.get('water_management.reservoirs.parameters.variables').items():

--- a/mosartwmpy/reservoirs/grid.py
+++ b/mosartwmpy/reservoirs/grid.py
@@ -37,6 +37,8 @@ def load_reservoirs(self, config: Benedict, parameters: Parameters) -> None:
     self.reservoir_surface_area = self.reservoir_surface_area * 1.0e6
     # capacity from millions m^3 to m^3
     self.reservoir_storage_capacity = self.reservoir_storage_capacity * 1.0e6
+    # min capacity from millions m^3 to m^3
+    self.reservoir_storage_minimum = self.reservoir_storage_minimum * 1.0e6
 
     # reservoir dependency database file
     self.reservoir_dependency_database = pd.read_parquet(

--- a/mosartwmpy/reservoirs/istarf.py
+++ b/mosartwmpy/reservoirs/istarf.py
@@ -14,7 +14,7 @@ def istarf_release(state: State, grid: Grid, config: Benedict, parameters: Param
     # estimate reservoir release using ISTARF which is based on harmonic functions
 
     # restrict epiweek to [1, 52]
-    epiweek = np.minimum(float(get_epiweek_from_datetime(current_time)), 52.0)
+    epiweek = min(float(get_epiweek_from_datetime(current_time)), 52.0)
 
     daily_release = np.zeros(len(grid.reservoir_id))
 

--- a/mosartwmpy/reservoirs/regulation.py
+++ b/mosartwmpy/reservoirs/regulation.py
@@ -14,6 +14,7 @@ from numba.typed import List, Dict
     nopython=True,
     nogil=True,
     cache=True,
+    parallel=True,
 )
 def regulation(
     n,

--- a/mosartwmpy/reservoirs/regulation.py
+++ b/mosartwmpy/reservoirs/regulation.py
@@ -8,7 +8,7 @@ from numba.typed import List, Dict
 @nb.jit(
     "void("
         "int64, float64,"
-        "int64[:], float64[:], float64[:], float64[:],"
+        "int64[:], float64[:], float64[:], float64[:], float64[:],"
         "boolean[:], float64[:], float64[:], float64[:], float64[:], float64[:], float64"
     ")",
     nopython=True,
@@ -22,6 +22,7 @@ def regulation(
     reservoir_id,
     reservoir_surface_area,
     reservoir_storage_capacity,
+    reservoir_storage_minimum,
     euler_mask,
     channel_outflow_downstream,
     reservoir_release,
@@ -43,7 +44,8 @@ def regulation(
             evaporation = 1e6 * reservoir_potential_evaporation[i] * delta_t * reservoir_surface_area[i]
 
             minimum_flow = reservoir_runoff_capacity_parameter * reservoir_mean_inflow[i] * delta_t
-            minimum_storage = reservoir_runoff_capacity_parameter * reservoir_storage_capacity[i]
+            # minimum_storage = reservoir_runoff_capacity_parameter * reservoir_storage_capacity[i]
+            minimum_storage = reservoir_storage_minimum[i]
             maximum_storage = reservoir_storage_capacity[i]
 
             has_excess_storage = (inflow_volume + reservoir_storage[i] - outflow_volume - evaporation) >= maximum_storage

--- a/mosartwmpy/subnetwork/irrigation.py
+++ b/mosartwmpy/subnetwork/irrigation.py
@@ -30,7 +30,39 @@ def subnetwork_irrigation(
     irrigation_extraction_parameter,
     tiny_value,
 ):
-    """Tracks the supply of water from the subnetwork river channels extracted into the grid cells."""
+    """
+    Tracks the supply of water from the subnetwork river channels extracted into the grid cells.
+
+    Parameters:
+    n : int
+        Number of elements in the subnetwork.
+    mosart_mask : int64[:]
+        Mask indicating active subnetwork elements.
+    subnetwork_length : float64[:]
+        Length of each subnetwork element.
+    subnetwork_width : float64[:]
+        Width of each subnetwork element.
+    euler_mask : boolean[:]
+        Mask indicating elements to be processed.
+    subnetwork_depth : float64[:]
+        Depth of each subnetwork element.
+    subnetwork_storage : float64[:]
+        Storage volume of each subnetwork element.
+    grid_cell_unmet_demand : float64[:]
+        Unmet water demand for each grid cell.
+    grid_cell_supply : float64[:]
+        Water supply for each grid cell.
+    subnetwork_cross_section_area : float64[:]
+        Cross-sectional area of each subnetwork element.
+    subnetwork_wetness_perimeter : float64[:]
+        Wetness perimeter of each subnetwork element.
+    subnetwork_hydraulic_radii : float64[:]
+        Hydraulic radii of each subnetwork element.
+    irrigation_extraction_parameter : float64
+        Parameter for irrigation extraction.
+    tiny_value : float64
+        Small value to avoid division by zero.
+    """
 
     for i in nb.prange(n):
 

--- a/mosartwmpy/subnetwork/state.py
+++ b/mosartwmpy/subnetwork/state.py
@@ -11,7 +11,7 @@ import numba as nb
     cache=True,
 )
 def update_subnetwork_state(
-    i,
+    i,  # Index of the subnetwork element to update
     subnetwork_length,
     subnetwork_width,
     subnetwork_storage,
@@ -21,7 +21,20 @@ def update_subnetwork_state(
     subnetwork_hydraulic_radii,
     tiny_value,
 ):
-    """Updates the physical properties of the subnetwork river channels based on current state."""
+    """
+    Updates the physical properties of the subnetwork river channels based on current state.
+
+    Parameters:
+    i (int64): Index of the subnetwork.
+    subnetwork_length (float64[:]): Length of the subnetwork river channels.
+    subnetwork_width (float64[:]): Width of the subnetwork river channels.
+    subnetwork_storage (float64[:]): Storage of the subnetwork river channels.
+    subnetwork_cross_section_area (float64[:]): Cross-sectional area of the subnetwork river channels.
+    subnetwork_depth (float64[:]): Depth of the subnetwork river channels.
+    subnetwork_wetness_perimeter (float64[:]): Wetness perimeter of the subnetwork river channels.
+    subnetwork_hydraulic_radii (float64[:]): Hydraulic radii of the subnetwork river channels.
+    tiny_value (float64): A small value used to avoid division by zero.
+    """
 
     has_water = (subnetwork_length[i] > 0.0) and (subnetwork_storage[i] > 0.0)
 

--- a/mosartwmpy/update/update.py
+++ b/mosartwmpy/update/update.py
@@ -25,6 +25,7 @@ def update(state: State, grid: Grid, parameters: Parameters, config: Benedict, c
         grid (Grid): the model grid
         parameters (Parameters): the model parameters
         config (Benedict): the model configuration
+        current_time (datetime): the current simulation time
     """
 
     # size of flattened grid

--- a/mosartwmpy/update/update.py
+++ b/mosartwmpy/update/update.py
@@ -225,6 +225,7 @@ def update(state: State, grid: Grid, parameters: Parameters, config: Benedict, c
                     grid.reservoir_id,
                     grid.reservoir_surface_area,
                     grid.reservoir_storage_capacity,
+                    grid.reservoir_storage_minimum,
                     state.euler_mask,
                     state.channel_outflow_downstream,
                     state.reservoir_release,

--- a/setup.py
+++ b/setup.py
@@ -4,65 +4,70 @@ from setuptools import setup, find_packages
 
 def readme():
     """Return the contents of the project README file."""
-    with open('README.md') as f:
+    with open("README.md") as f:
         return f.read()
 
 
-version = re.search(r"__version__ = ['\"]([^'\"]*)['\"]", open('mosartwmpy/_version.py').read(), re.M).group(1)
+version = re.search(
+    r"__version__ = ['\"]([^'\"]*)['\"]", open("mosartwmpy/_version.py").read(), re.M
+).group(1)
 
 setup(
-    name='mosartwmpy',
+    name="mosartwmpy",
     version=version,
     packages=find_packages(),
-    url='https://github.com/IMMM-SFA/mosartwmpy',
-    license='BSD2-Simplified',
-    author='Travis Thurber',
-    author_email='travis.thurber@pnnl.gov',
-    description='Python implementation of MOSART-WM: A water routing and management model',
+    url="https://github.com/IMMM-SFA/mosartwmpy",
+    license="BSD2-Simplified",
+    author="Travis Thurber",
+    author_email="travis.thurber@pnnl.gov",
+    description="Python implementation of MOSART-WM: A water routing and management model",
     long_description=readme(),
     long_description_content_type="text/markdown",
-    python_requires='>=3.7.*, <4',
+    python_requires=">=3.9,<3.13",
     include_package_data=True,
     entry_points={
-        'console_scripts': [
-            'create_grand_parameters = mosartwmpy.utilities.create_grand_parameters:create_grand_parameters',
-            'bil_to_parquet = mosartwmpy.utilities.bil_to_parquet:bil_to_parquet',
+        "console_scripts": [
+            "create_grand_parameters = mosartwmpy.utilities.create_grand_parameters:create_grand_parameters",
+            "bil_to_parquet = mosartwmpy.utilities.bil_to_parquet:bil_to_parquet",
         ]
     },
     install_requires=[
-        'bmipy==2.0',
-        'click==8.0.1',
-        'contextily==1.2.0',
-        'dask[complete]==2021.10.0',
-        'geopandas==0.10.2',
-        'h5netcdf==0.11.0',
-        'hvplot==0.7.3',
-        'matplotlib==3.4.3',
-        'nc-time-axis==1.4.0',
-        'netCDF4==1.5.7',
-        'numba==0.53.1',
-        'numpy==1.20.3',
-        'pandas==1.3.4',
-        'pathvalidate==2.5.0',
-        'psutil==5.8.0',
-        'pyarrow==6.0.0',
-        'python-benedict==0.24.3',
-        'regex==2021.10.23',
-        'requests==2.26.0',
-        'rioxarray==0.8.0',
-        'tqdm==4.62.3',
-        'xarray==0.19.0'
+        "bmipy>=2.0",
+        "click>=8.0.1",
+        "contextily>=1.2.0",
+        "dask[complete]>=2021.10.0",
+        "geopandas>=0.10.2",
+        "h5netcdf>=0.11.0",
+        "hvplot>=0.7.3",
+        "matplotlib>=3.4.3",
+        "nc-time-axis>=1.4.0",
+        "netCDF4>=1.5.7",
+        "numba>=0.53.1",
+        "numpy>=1.20.3,<2.0",
+        "pandas>=1.3.4",
+        "pathvalidate>=2.5.0",
+        "psutil>=5.8.0",
+        "pyarrow>=6.0.0",
+        "pyomo>=6.2",
+        "python-benedict>=0.24.3",
+        "regex>=2021.10.23",
+        "requests>=2.26.0",
+        "rioxarray>=0.8.0",
+        "tqdm>=4.62.3",
+        "xarray>=0.19.0",
     ],
     extras_require={
-        'dev': [
-            'build~=0.7.0',
-            'nbsphinx~=0.8.7',
-            'recommonmark~=0.7.1',
-            'setuptools~=58.3.0',
-            'sphinx~=4.2.0',
-            'sphinx-panels~=0.6.0',
-            'sphinx-rtd-theme~=1.0.0',
-            'twine~=3.4.2'
+        "dev": [
+            "build>=0.7.0",
+            "ipython",
+            "nbsphinx>=0.8.7",
+            "recommonmark>=0.7.1",
+            "setuptools>=58.3.0",
+            "sphinx>=5",
+            "sphinx_design",
+            "sphinx-rtd-theme>=1.0.0",
+            "twine>=3.4.2",
+            "pre-commit",
         ]
-    }
+    },
 )


### PR DESCRIPTION
added a reservoir min storage value to the reservoir file to improve on the default % of max storage threshold used
migrated the reservoir file from netCDF to parquet to make it easier to modify and read. the reservoir file contains fixed parameter values for each reservoir and does not require spatial or time indexing