### PR TITLE
specify min reservoir storage and res storage filetype options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 /.vscode
+/testing

--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+/.vscode

--- a/mosartwmpy/config_defaults.yaml
+++ b/mosartwmpy/config_defaults.yaml
@@ -405,6 +405,10 @@ water_management:
                 streamflow_month_index: MONTH_INDEX
                 # mean streamflow for month
                 streamflow: MEAN_FLOW
+        # optional initial reservoir storage file (csv or parquet); columns: GRAND_ID, GRID_CELL_INDEX, RES_NAME (identifiers), CAP_INIT (initial storage [million m3])
+        # if absent or path is null, defaults to 0.9 * storage capacity; missing values within the file also fall back to the default
+        initial_storage:
+            path: ~
         # database of monthly mean demand for each reservoir
         demand:
           # path to the demand file; can be absolute or relative to the source code root

--- a/mosartwmpy/config_defaults.yaml
+++ b/mosartwmpy/config_defaults.yaml
@@ -339,6 +339,8 @@ water_management:
                 reservoir_surface_area: AREA_SKM
                 # storage capacity field name [million m3]
                 reservoir_storage_capacity: CAP_MCM
+                # minimum storage capacity field name [million m3]
+                reservoir_minimum_storage: CAP_MIN
                 # depth field name [m]
                 reservoir_depth: DEPTH_M
                 # use irrigation field name

--- a/mosartwmpy/grid/grid.py
+++ b/mosartwmpy/grid/grid.py
@@ -73,6 +73,7 @@ class Grid:
     reservoir_length: np.ndarray = np.empty(0)
     reservoir_surface_area: np.ndarray = np.empty(0)
     reservoir_storage_capacity: np.ndarray = np.empty(0)
+    reservoir_minimum_storage: np.ndarray = np.empty(0)
     reservoir_depth: np.ndarray = np.empty(0)
     reservoir_use_irrigation: np.ndarray = np.empty(0)
     reservoir_use_electricity: np.ndarray = np.empty(0)

--- a/mosartwmpy/grid/grid.py
+++ b/mosartwmpy/grid/grid.py
@@ -523,7 +523,7 @@ class Grid:
         # recreate the numba grid to reservoir map
         if grid.reservoir_dependency_database.size > 0:
             for grid_cell_id, group in grid.reservoir_dependency_database.reset_index().groupby('grid_cell_id'):
-                grid.grid_index_to_reservoirs_map[grid_cell_id] = group.reservoir_id.values
+                grid.grid_index_to_reservoirs_map[grid_cell_id] = group.reservoir_id.values.copy()
         
         return grid
 

--- a/mosartwmpy/reservoirs/grid.py
+++ b/mosartwmpy/reservoirs/grid.py
@@ -79,7 +79,7 @@ def load_reservoirs(self, config: Benedict, parameters: Parameters) -> None:
         value_type=types.int64[:],
     )
     for grid_cell_id, group in self.reservoir_dependency_database.groupby('grid_cell_id'):
-        self.grid_index_to_reservoirs_map[grid_cell_id] = group.reservoir_id.values
+        self.grid_index_to_reservoirs_map[grid_cell_id] = group.reservoir_id.values.copy()
 
     # index by grid cell
     self.reservoir_dependency_database = self.reservoir_dependency_database.set_index('grid_cell_id').sort_index()

--- a/mosartwmpy/reservoirs/grid.py
+++ b/mosartwmpy/reservoirs/grid.py
@@ -4,6 +4,7 @@ import xarray as xr
 
 from numba.core import types
 from numba.typed import Dict
+from pathlib import Path
 from xarray import concat, open_dataset, DataArray
 from benedict.dicts import benedict as Benedict
 
@@ -18,15 +19,23 @@ def load_reservoirs(self, config: Benedict, parameters: Parameters) -> None:
         parameters (Parameters): the model parameters
     """
 
-    # reservoir parameter file
-    reservoirs_file = open_dataset(config.get('water_management.reservoirs.parameters.path'))
+    # reservoir parameter file — supports .nc (netCDF), .parquet, or .csv
+    reservoir_path = config.get('water_management.reservoirs.parameters.path')
+    suffix = Path(reservoir_path).suffix.lower()
+    if suffix in ('.parquet',):
+        reservoir_df = pd.read_parquet(reservoir_path)
+    elif suffix in ('.csv',):
+        reservoir_df = pd.read_csv(reservoir_path)
+    else:
+        reservoirs_file = open_dataset(reservoir_path)
+        reservoir_df = reservoirs_file.to_dataframe()
+        reservoirs_file.close()
     reservoirs = pd.DataFrame(index=self.id).merge(
-        reservoirs_file.to_dataframe(),
+        reservoir_df,
         how='left',
         left_index=True,
         right_on=config.get('water_management.reservoirs.parameters.grid_cell_index'),
     )
-    reservoirs_file.close()
 
     # load reservoir variables
     # coerce to numpy arrays: under pandas with pyarrow, string columns (e.g. the
@@ -41,6 +50,16 @@ def load_reservoirs(self, config: Benedict, parameters: Parameters) -> None:
     self.reservoir_surface_area = self.reservoir_surface_area * 1.0e6
     # capacity from millions m^3 to m^3
     self.reservoir_storage_capacity = self.reservoir_storage_capacity * 1.0e6
+
+    # minimum storage: use CAP_MIN [million m3] from the file when present,
+    # otherwise fall back to reservoir_runoff_capacity_parameter * storage_capacity
+    cap_min_col = config.get('water_management.reservoirs.parameters.minimum_storage_variable', 'CAP_MIN')
+    if cap_min_col in reservoirs.columns and reservoirs[cap_min_col].notna().any():
+        cap_min_m3 = np.asarray(reservoirs[cap_min_col].values, dtype=np.float64) * 1.0e6
+        fallback = parameters.reservoir_runoff_capacity_parameter * self.reservoir_storage_capacity
+        self.reservoir_minimum_storage = np.where(np.isfinite(cap_min_m3), cap_min_m3, fallback)
+    else:
+        self.reservoir_minimum_storage = parameters.reservoir_runoff_capacity_parameter * self.reservoir_storage_capacity
 
     # reservoir dependency database file
     self.reservoir_dependency_database = pd.read_parquet(

--- a/mosartwmpy/reservoirs/regulation.py
+++ b/mosartwmpy/reservoirs/regulation.py
@@ -8,7 +8,7 @@ from numba.typed import List, Dict
 @nb.jit(
     "void("
         "int64, float64,"
-        "int64[:], float64[:], float64[:], float64[:],"
+        "int64[:], float64[:], float64[:], float64[:], float64[:],"
         "boolean[:], float64[:], float64[:], float64[:], float64[:], float64[:], float64"
     ")",
     nopython=True,
@@ -22,6 +22,7 @@ def regulation(
     reservoir_id,
     reservoir_surface_area,
     reservoir_storage_capacity,
+    reservoir_minimum_storage,
     euler_mask,
     channel_outflow_downstream,
     reservoir_release,
@@ -43,7 +44,7 @@ def regulation(
             evaporation = 1e6 * reservoir_potential_evaporation[i] * delta_t * reservoir_surface_area[i]
 
             minimum_flow = reservoir_runoff_capacity_parameter * reservoir_mean_inflow[i] * delta_t
-            minimum_storage = reservoir_runoff_capacity_parameter * reservoir_storage_capacity[i]
+            minimum_storage = reservoir_minimum_storage[i]
             maximum_storage = reservoir_storage_capacity[i]
 
             has_excess_storage = (inflow_volume + reservoir_storage[i] - outflow_volume - evaporation) >= maximum_storage

--- a/mosartwmpy/reservoirs/state.py
+++ b/mosartwmpy/reservoirs/state.py
@@ -34,7 +34,7 @@ def _load_initial_storage(grid: Grid, config: Benedict, default_storage: np.ndar
     """Loads per-reservoir initial storage from an optional file, falling back to default for missing values.
 
     The file (csv or parquet) must contain a CAP_INIT column [million m3] and at least one of:
-    GRAND_ID, GRID_CELL_INDEX, or RES_NAME as a join key. Matching is attempted in that priority order.
+    GRAND_ID or GRID_CELL_INDEX as a join key. Matching is attempted in that priority order.
     Reservoirs not matched in the file use default_storage.
     """
     init_path = config.get('water_management.reservoirs.initial_storage.path')
@@ -68,24 +68,42 @@ def _load_initial_storage(grid: Grid, config: Benedict, default_storage: np.ndar
     for join_key, grid_attr in [
         (res_id_col, 'reservoir_id'),
         (grid_idx_col, 'reservoir_grid_index'),
-        ('RES_NAME', None),
     ]:
         if join_key not in df.columns:
             continue
         grid_vals = getattr(grid, grid_attr, None) if grid_attr else None
         if grid_vals is None:
             continue
-        lookup = df.dropna(subset=[join_key, 'CAP_INIT']).set_index(join_key)['CAP_INIT']
+
+        deduped = df.dropna(subset=[join_key, 'CAP_INIT'])
+        n_dupes = deduped.duplicated(subset=[join_key]).sum()
+        if n_dupes:
+            logger.warning(
+                '%d duplicate "%s" value(s) in initial storage file — keeping last occurrence',
+                n_dupes, join_key,
+            )
+            deduped = deduped.drop_duplicates(subset=[join_key], keep='last')
+
+        lookup = deduped.set_index(join_key)['CAP_INIT']
         matched = pd.Series(grid_vals).map(lookup)
         valid = matched.notna().values
-        if valid.any():
-            storage[valid] = matched[valid].values.astype(np.float64) * 1.0e6
-            missing = (~valid).sum()
-            if missing:
-                logger.info(
-                    '%d reservoir(s) not matched in initial storage file — using default (0.9 * capacity)',
-                    missing,
-                )
+
+        if not valid.any():
+            logger.info(
+                'Identifier column "%s" present but matched no reservoirs — trying next identifier',
+                join_key,
+            )
+            continue
+
+        storage[valid] = matched[valid].values.astype(np.float64) * 1.0e6
+
+        is_reservoir = np.isfinite(np.asarray(grid_vals, dtype=np.float64))
+        missing = int((is_reservoir & ~valid).sum())
+        if missing:
+            logger.info(
+                '%d reservoir(s) not matched in initial storage file — using default (0.9 * capacity)',
+                missing,
+            )
         break
     else:
         logger.warning(

--- a/mosartwmpy/reservoirs/state.py
+++ b/mosartwmpy/reservoirs/state.py
@@ -1,9 +1,14 @@
+import logging
 import numpy as np
+import pandas as pd
 
+from pathlib import Path
 from benedict.dicts import benedict as Benedict
 
 from mosartwmpy.config.parameters import Parameters
 from mosartwmpy.grid.grid import Grid
+
+logger = logging.getLogger(__name__)
 
 
 def initialize_reservoir_state(self, grid: Grid, config: Benedict, parameters: Parameters) -> None:
@@ -18,10 +23,77 @@ def initialize_reservoir_state(self, grid: Grid, config: Benedict, parameters: P
     # reservoir storage at the start of the operation year
     self.reservoir_storage_operation_year_start = 0.85 * grid.reservoir_storage_capacity
 
-    # initial storage in each reservoir
-    self.reservoir_storage = 0.9 * grid.reservoir_storage_capacity
+    # initial storage in each reservoir — default to 90% of capacity
+    default_storage = 0.9 * grid.reservoir_storage_capacity
+    self.reservoir_storage = _load_initial_storage(grid, config, default_storage)
 
     initialize_reservoir_start_of_operation_year(self, grid, config, parameters)
+
+
+def _load_initial_storage(grid: Grid, config: Benedict, default_storage: np.ndarray) -> np.ndarray:
+    """Loads per-reservoir initial storage from an optional file, falling back to default for missing values.
+
+    The file (csv or parquet) must contain a CAP_INIT column [million m3] and at least one of:
+    GRAND_ID, GRID_CELL_INDEX, or RES_NAME as a join key. Matching is attempted in that priority order.
+    Reservoirs not matched in the file use default_storage.
+    """
+    init_path = config.get('water_management.reservoirs.initial_storage.path')
+    if not init_path:
+        return default_storage
+
+    path = Path(init_path)
+    if not path.exists():
+        logger.warning('Reservoir initial storage file not found: %s — using default (0.9 * capacity)', init_path)
+        return default_storage
+
+    suffix = path.suffix.lower()
+    if suffix == '.parquet':
+        df = pd.read_parquet(path)
+    elif suffix == '.csv':
+        df = pd.read_csv(path)
+    else:
+        logger.warning('Unsupported initial storage file format "%s" — using default (0.9 * capacity)', suffix)
+        return default_storage
+
+    if 'CAP_INIT' not in df.columns:
+        logger.warning('CAP_INIT column missing from initial storage file — using default (0.9 * capacity)')
+        return default_storage
+
+    # build a Series indexed by grid position, matching on the first available identifier
+    res_id_col = config.get('water_management.reservoirs.parameters.variables.reservoir_id', 'GRAND_ID')
+    grid_idx_col = config.get('water_management.reservoirs.parameters.grid_cell_index', 'GRID_CELL_INDEX')
+
+    storage = default_storage.copy()
+
+    for join_key, grid_attr in [
+        (res_id_col, 'reservoir_id'),
+        (grid_idx_col, 'reservoir_grid_index'),
+        ('RES_NAME', None),
+    ]:
+        if join_key not in df.columns:
+            continue
+        grid_vals = getattr(grid, grid_attr, None) if grid_attr else None
+        if grid_vals is None:
+            continue
+        lookup = df.dropna(subset=[join_key, 'CAP_INIT']).set_index(join_key)['CAP_INIT']
+        matched = pd.Series(grid_vals).map(lookup)
+        valid = matched.notna().values
+        if valid.any():
+            storage[valid] = matched[valid].values.astype(np.float64) * 1.0e6
+            missing = (~valid).sum()
+            if missing:
+                logger.info(
+                    '%d reservoir(s) not matched in initial storage file — using default (0.9 * capacity)',
+                    missing,
+                )
+        break
+    else:
+        logger.warning(
+            'No usable identifier column (%s, %s, RES_NAME) found in initial storage file — using default',
+            res_id_col, grid_idx_col,
+        )
+
+    return storage
 
 
 def initialize_reservoir_start_of_operation_year(self, grid: Grid, config: Benedict, parameters: Parameters) -> None:

--- a/mosartwmpy/update/update.py
+++ b/mosartwmpy/update/update.py
@@ -242,6 +242,7 @@ def update(state: State, grid: Grid, parameters: Parameters, config: Benedict, c
                     grid.reservoir_id,
                     grid.reservoir_surface_area,
                     grid.reservoir_storage_capacity,
+                    grid.reservoir_minimum_storage,
                     state.euler_mask,
                     state.channel_outflow_downstream,
                     state.reservoir_release,


### PR DESCRIPTION
- provided an option to include a minimum storage column in the reservoir storage file - default: CAP_MIN and specified in units of million cubic meters like CAP_MCM

- provided options for the reservoir file to be a parquet file or a csv file in addition to the current netCDF filetype. the reservoir file contains static values per reservoir and has only a reservoir index dimension, making the netCDF format unnecessary. the parquet format and csv format make revising the reservoir file and looking at values more user-friendly
