### PR TITLE
Reservoir minimum storage, initial storage, and parameter file formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 /.vscode
+/testing

--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+/.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ on `main` was never published; this release supersedes it.
   a Parquet or CSV file with a `CAP_INIT` column (million m<sup>3</sup>) to set starting storage,
   joined on `GRAND_ID` or `GRID_CELL_INDEX`. Values are optional per reservoir; anything unmatched
   falls back to the default 90% of capacity. (Dan Broman)
+- **MSD-LIVE downloads without a plain URL.** Files on MSD-LIVE records created from July 2023
+  onward live in a project owned S3 bucket rather than InvenioRDM's managed storage, so the
+  Invenio file API lists only a placeholder and no fetchable URL exists. `mosartwmpy.download`
+  now recognizes a MSD-LIVE record URL and retrieves those files by requesting anonymous,
+  read only credentials and signing the request with AWS Signature Version 4. No account is
+  required and no new dependency was added. Zenodo hosted datasets are still downloaded
+  directly. A manifest entry for such a record gives the record URL plus an optional
+  `filename`; without it the largest archive in the record is used.
 
 ### Changed
 - **numpy 2 support.** Requires `numpy>=2.0` and `numba>=0.60`; minimum Python raised to 3.10.
@@ -44,6 +52,9 @@ on `main` was never published; this release supersedes it.
 - Input reading fills NaNs more robustly regardless of how the input arrives, and sorts
   grid/runoff/demand datasets by coordinate on open.
 - The model logs its version on startup.
+- The `sample_input` dataset now points at MSD-LIVE v0.0.8 (doi `10.57931/3398687`), whose
+  reservoir parameters carry `CAP_MIN` and are provided as netCDF, Parquet, and CSV. Reservoir
+  operating rule assignments are unchanged from v0.0.6.
 
 ### Fixed
 - **Reservoir regulation numba race condition.** Inner accumulation loops in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ on `main` was never published; this release supersedes it.
   `water_management.reservoirs.parameters.minimum_storage_variable`. Reservoirs with no value, and
   files with no such column, fall back to the previous 10% of capacity, so existing input keeps
   working unchanged. Note that ISTARF release rules still derive their normal operating range from
-  storage capacity alone and do not respect `CAP_MIN`. (Dan Broman)
+  storage capacity alone and do not respect `CAP_MIN` (tracked in #124). (Dan Broman)
 - **Reservoir parameter files in Parquet or CSV.** The reservoir parameter file holds static
   per-reservoir values with a single dimension, so netCDF is no longer required; `.parquet` and
   `.csv` are now accepted and selected by file extension, which makes the values easier to inspect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ on `main` was never published; this release supersedes it.
   irrigation demand before nonirrigation (value `1`) versus nonirrigation first (`0`). Adds
   `irrigation_consumption_deficit` and `nonirrigation_consumption_deficit` output variables.
   See the "return flow" section of the README for configuration.
+- **Per-reservoir minimum storage.** An optional `CAP_MIN` column in the reservoir parameter file
+  (million m<sup>3</sup>, like `CAP_MCM`) sets the minimum storage below which a reservoir will not
+  release, replacing the hardcoded 10% of capacity. The column name is configurable via
+  `water_management.reservoirs.parameters.minimum_storage_variable`. Reservoirs with no value, and
+  files with no such column, fall back to the previous 10% of capacity, so existing input keeps
+  working unchanged. Note that ISTARF release rules still derive their normal operating range from
+  storage capacity alone and do not respect `CAP_MIN`. (Dan Broman)
+- **Reservoir parameter files in Parquet or CSV.** The reservoir parameter file holds static
+  per-reservoir values with a single dimension, so netCDF is no longer required; `.parquet` and
+  `.csv` are now accepted and selected by file extension, which makes the values easier to inspect
+  and edit. `create_grand_parameters` writes whichever of the three formats the output path names.
+  (Dan Broman)
+- **Optional initial reservoir storage.** `water_management.reservoirs.initial_storage.path` accepts
+  a Parquet or CSV file with a `CAP_INIT` column (million m<sup>3</sup>) to set starting storage,
+  joined on `GRAND_ID` or `GRID_CELL_INDEX`. Values are optional per reservoir; anything unmatched
+  falls back to the default 90% of capacity. (Dan Broman)
 
 ### Changed
 - **numpy 2 support.** Requires `numpy>=2.0` and `numba>=0.60`; minimum Python raised to 3.10.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Reservoirs will not release water below a minimum (dead) storage. Provide a per-
 > ```
 
 Reservoirs with no value, and files with no such column, fall back to 10% of storage capacity, which was the behavior before this field existed.
-Note that ISTARF release rules derive their normal operating range from storage capacity and do not currently respect `CAP_MIN`.
+Note that ISTARF release rules derive their normal operating range from storage capacity and do not currently respect `CAP_MIN` ([#124](https://github.com/IMMM-SFA/mosartwmpy/issues/124)).
 
 #### initial reservoir storage
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Download a sample input dataset spanning May 1981 by running the following and s
 python -m mosartwmpy.download
 ```
 
+The datasets are hosted publicly on Zenodo and MSD-LIVE; no account or credentials are required.
+
 Settings are defined by the merger of the `mosartwmpy/config_defaults.yaml` and a user specified file which can override any of the default settings. Create a `config.yaml` file that defines your simulation (if you chose an alternate download directory in the step above, you will need to update the paths to point at your data):
 
 > `config.yaml`

--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ Settings are defined by the merger of the `mosartwmpy/config_defaults.yaml` and 
 >   reservoirs:
 >     enable_istarf: true
 >     parameters:
+>       # netCDF, parquet, or csv; see "reservoir parameter file formats" below
 >       path: ./input/reservoirs/reservoirs.nc
+>     # optional starting storage; see "initial reservoir storage" below
+>     # initial_storage:
+>     #   path: ./input/reservoirs/initial_storage.csv
 >     dependencies:
 >       path: ./input/reservoirs/dependency_database.parquet
 >     streamflow:
@@ -94,6 +98,46 @@ Efforts are under way for more robust demand handling.
 Dams/reservoirs require four different input files: the physical characteristics, the average monthly flow expected during the simulation period, the average monthly demand expected during the simulation period, and a database mapping each GRanD ID to grid cell IDs allowed to extract water from it.
 These dam/reservoir input files can be generated from raw GRanD data, raw elevation data, and raw ISTARF data using the [provided utility](https://github.com/IMMM-SFA/mosartwmpy/blob/main/mosartwmpy/utilities/CREATE_GRAND_PARAMETERS.md).
 The best way to understand the expected format of the input files is to examine the sample inputs provided by the download utility: `python -m mosartwmpy.download`.
+
+#### reservoir parameter file formats
+
+The reservoir parameter file holds static values with only a reservoir dimension, so it can be provided as netCDF (`.nc`), Parquet (`.parquet`), or CSV (`.csv`).
+The format is chosen from the file extension. Parquet and CSV are easier to inspect and edit by hand:
+
+> ```yaml
+> water_management:
+>   reservoirs:
+>     parameters:
+>       path: ./input/reservoirs/reservoirs.parquet
+> ```
+
+#### minimum reservoir storage
+
+Reservoirs will not release water below a minimum (dead) storage. Provide a per-reservoir value in a `CAP_MIN` column, in million m<sup>3</sup> like `CAP_MCM`:
+
+> ```yaml
+> water_management:
+>   reservoirs:
+>     parameters:
+>       # column holding the minimum storage; defaults to CAP_MIN
+>       minimum_storage_variable: CAP_MIN
+> ```
+
+Reservoirs with no value, and files with no such column, fall back to 10% of storage capacity, which was the behavior before this field existed.
+Note that ISTARF release rules derive their normal operating range from storage capacity and do not currently respect `CAP_MIN`.
+
+#### initial reservoir storage
+
+Starting reservoir storage defaults to 90% of capacity. To set it explicitly, point at a Parquet or CSV file with a `CAP_INIT` column in million m<sup>3</sup>, joined on either `GRAND_ID` or `GRID_CELL_INDEX`:
+
+> ```yaml
+> water_management:
+>   reservoirs:
+>     initial_storage:
+>       path: ./input/reservoirs/initial_storage.csv
+> ```
+
+Values are optional per reservoir; any reservoir absent from the file, or with a blank `CAP_INIT`, falls back to 90% of capacity.
 
 #### multi-file input
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,36 +1,46 @@
 # Releasing mosartwmpy
 
-## Blocking for v1.0.0: publish the sample input data
+## Sample input data on MSD-LIVE
 
-The reservoir parameter files bundled in the published sample input data predate the
-`CAP_MIN` minimum storage column, so that feature cannot be exercised against the
-downloadable inputs until a new data package is published.
+The `sample_input` entry in `mosartwmpy/data_manifest.yaml` points at MSD-LIVE record
+[`m28qs-54544`](https://data.msdlive.org/records/m28qs-54544) (v0.0.8, doi
+`10.57931/3398687`), whose reservoir parameters include the `CAP_MIN` minimum storage
+column and ship as netCDF, Parquet, and CSV.
 
-Before tagging v1.0.0:
+MSD-LIVE stores files in two different backends, which affects how they can be fetched:
 
-1. Upload the new sample input package (including reservoir parameter files with `CAP_MIN`)
-   as a new version of the MSD-LIVE record.
-2. Update the `sample_input` URL in `mosartwmpy/data_manifest.yaml` to the new record.
-3. Re-run `python -m mosartwmpy.download` and confirm a fresh run picks up `CAP_MIN`.
+- Records up to v0.0.6 keep their files in InvenioRDM's managed storage, so
+  `https://data.msdlive.org/api/records/<id>/files/<name>/content` serves a signed
+  redirect that any HTTP client can follow.
+- Records from v0.0.7 (July 2023) onward keep their files in a project owned S3 bucket
+  reached through a per record access point. For these, the Invenio file API lists only a
+  small placeholder file, `/content` returns 404, and **no plain URL exists**.
 
-Without `CAP_MIN` present the model still runs, falling back to 10% of storage capacity,
-so this blocks feature verification rather than the release itself.
+`mosartwmpy/utilities/msdlive.py` handles the second case: it requests anonymous, read
+only AWS credentials and signs requests against the record's access point using
+Signature Version 4. No MSD-LIVE account is needed, and no `boto3` dependency was added,
+since `requests` plus `hmac`/`hashlib` is enough. `download_data` picks the transport
+from the manifest URL, so Zenodo entries are unaffected.
 
-### Note on the existing records
+Two consequences worth knowing:
 
-The manifest points at [`m6pp5-7xt54`](https://data.msdlive.org/records/m6pp5-7xt54) (v0.0.6),
-which is correct: it holds the real 702 MB `mosartwmpy_sample_input_data_1980_1985.zip`.
-The later [`syt0j-x0203`](https://data.msdlive.org/records/syt0j-x0203) (v0.0.7) contains only a
-12-byte `dummy.txt` placeholder and no data, so it must not be linked from the manifest.
-Publishing the new version is also a chance to give v0.0.7 real content or retract it.
+- A manifest entry for one of these records is the record URL, not a file URL, plus an
+  optional `filename`. Without `filename` the largest `.zip` in the record is used.
+- The credentials endpoint is undocumented. If MSD-LIVE later registers project bucket
+  files with Invenio, or changes that endpoint, this code path can be dropped in favor of
+  a plain URL. `../msdlive-test/notes.md` in the sibling scratch repo has the full
+  investigation and the requests filed with the MSD-LIVE team.
 
-Both records share concept id `kehjf-ap948`. Note that the browser-facing
-`/records/<id>/files/<name>?download=1` URL is hotlink protected and returns 403 to
-non-browser clients; the API path used by the download utility works:
+Publishing a new data version is also a chance to give
+[`syt0j-x0203`](https://data.msdlive.org/records/syt0j-x0203) (v0.0.7) a DOI-visible fix
+or retract it; it holds real data but has never been reachable through the download
+utility.
 
-```
-https://data.msdlive.org/api/records/<id>/files/<name>/content
-```
+### After publishing a new data version
+
+1. Update `sample_input.url` in `mosartwmpy/data_manifest.yaml` to the new record URL.
+2. Run `python -m mosartwmpy.download`, select `sample_input`, and confirm the reservoir
+   parameter file has the expected columns.
 
 ## Version
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,15 +9,28 @@ downloadable inputs until a new data package is published.
 Before tagging v1.0.0:
 
 1. Upload the new sample input package (including reservoir parameter files with `CAP_MIN`)
-   to MSD-LIVE.
+   as a new version of the MSD-LIVE record.
 2. Update the `sample_input` URL in `mosartwmpy/data_manifest.yaml` to the new record.
-   It currently points at [`m6pp5-7xt54`](https://data.msdlive.org/records/m6pp5-7xt54)
-   (v0.0.6), which is already behind [`syt0j-x0203`](https://data.msdlive.org/records/syt0j-x0203)
-   (v0.0.7).
 3. Re-run `python -m mosartwmpy.download` and confirm a fresh run picks up `CAP_MIN`.
 
 Without `CAP_MIN` present the model still runs, falling back to 10% of storage capacity,
 so this blocks feature verification rather than the release itself.
+
+### Note on the existing records
+
+The manifest points at [`m6pp5-7xt54`](https://data.msdlive.org/records/m6pp5-7xt54) (v0.0.6),
+which is correct: it holds the real 702 MB `mosartwmpy_sample_input_data_1980_1985.zip`.
+The later [`syt0j-x0203`](https://data.msdlive.org/records/syt0j-x0203) (v0.0.7) contains only a
+12-byte `dummy.txt` placeholder and no data, so it must not be linked from the manifest.
+Publishing the new version is also a chance to give v0.0.7 real content or retract it.
+
+Both records share concept id `kehjf-ap948`. Note that the browser-facing
+`/records/<id>/files/<name>?download=1` URL is hotlink protected and returns 403 to
+non-browser clients; the API path used by the download utility works:
+
+```
+https://data.msdlive.org/api/records/<id>/files/<name>/content
+```
 
 ## Version
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,24 @@
 # Releasing mosartwmpy
 
+## Blocking for v1.0.0: publish the sample input data
+
+The reservoir parameter files bundled in the published sample input data predate the
+`CAP_MIN` minimum storage column, so that feature cannot be exercised against the
+downloadable inputs until a new data package is published.
+
+Before tagging v1.0.0:
+
+1. Upload the new sample input package (including reservoir parameter files with `CAP_MIN`)
+   to MSD-LIVE.
+2. Update the `sample_input` URL in `mosartwmpy/data_manifest.yaml` to the new record.
+   It currently points at [`m6pp5-7xt54`](https://data.msdlive.org/records/m6pp5-7xt54)
+   (v0.0.6), which is already behind [`syt0j-x0203`](https://data.msdlive.org/records/syt0j-x0203)
+   (v0.0.7).
+3. Re-run `python -m mosartwmpy.download` and confirm a fresh run picks up `CAP_MIN`.
+
+Without `CAP_MIN` present the model still runs, falling back to 10% of storage capacity,
+so this blocks feature verification rather than the release itself.
+
 ## Version
 
 The version lives in `mosartwmpy/_version.py` and is read by `setup.py`. Bump it

--- a/mosartwmpy/config_defaults.yaml
+++ b/mosartwmpy/config_defaults.yaml
@@ -325,6 +325,9 @@ water_management:
             path: ./input/reservoirs/reservoirs.nc
             # grid cell index field
             grid_cell_index: GRID_CELL_INDEX
+            # optional minimum (dead) storage field name [million m3]; reservoirs missing a value
+            # here fall back to 0.1 * storage capacity, which was the behavior before this field existed
+            minimum_storage_variable: CAP_MIN
             # variable field names
             variables:
                 # reservoir id field name - typically the GRanD ID
@@ -339,8 +342,6 @@ water_management:
                 reservoir_surface_area: AREA_SKM
                 # storage capacity field name [million m3]
                 reservoir_storage_capacity: CAP_MCM
-                # minimum storage capacity field name [million m3]
-                reservoir_minimum_storage: CAP_MIN
                 # depth field name [m]
                 reservoir_depth: DEPTH_M
                 # use irrigation field name

--- a/mosartwmpy/config_defaults.yaml
+++ b/mosartwmpy/config_defaults.yaml
@@ -405,6 +405,10 @@ water_management:
                 streamflow_month_index: MONTH_INDEX
                 # mean streamflow for month
                 streamflow: MEAN_FLOW
+        # optional initial reservoir storage file (csv or parquet); columns: GRAND_ID, GRID_CELL_INDEX, RES_NAME (identifiers), CAP_INIT (initial storage [million m3])
+        # if absent or path is null, defaults to 0.9 * storage capacity; missing values within the file also fall back to the default
+        initial_storage:
+            path: ~
         # database of monthly mean demand for each reservoir
         demand:
           # path to the demand file; can be absolute or relative to the source code root

--- a/mosartwmpy/config_defaults.yaml
+++ b/mosartwmpy/config_defaults.yaml
@@ -339,6 +339,8 @@ water_management:
                 reservoir_surface_area: AREA_SKM
                 # storage capacity field name [million m3]
                 reservoir_storage_capacity: CAP_MCM
+                # minimum storage capacity field name [million m3]
+                reservoir_minimum_storage: CAP_MIN
                 # depth field name [m]
                 reservoir_depth: DEPTH_M
                 # use irrigation field name

--- a/mosartwmpy/data_manifest.yaml
+++ b/mosartwmpy/data_manifest.yaml
@@ -6,6 +6,9 @@ tutorial:
   destination: ./
 
 sample_input:
+  # TODO before releasing v1.0.0: point this at the new MSD-LIVE record whose reservoir
+  # parameter files include the CAP_MIN minimum storage column. This URL is record
+  # m6pp5-7xt54 (v0.0.6), already behind syt0j-x0203 (v0.0.7). See RELEASING.md.
   description: Sample input dataset that can be used for testing and development; covers 1980 - 1985.
   url: https://data.msdlive.org/records/m6pp5-7xt54/files/mosartwmpy_sample_input_data_1980_1985.zip?download=1
   destination: ./

--- a/mosartwmpy/data_manifest.yaml
+++ b/mosartwmpy/data_manifest.yaml
@@ -6,11 +6,14 @@ tutorial:
   destination: ./
 
 sample_input:
-  # TODO before releasing v1.0.0: point this at the new MSD-LIVE record whose reservoir
-  # parameter files include the CAP_MIN minimum storage column. This URL is record
-  # m6pp5-7xt54 (v0.0.6), already behind syt0j-x0203 (v0.0.7). See RELEASING.md.
+  # v0.0.8 (doi 10.57931/3398687); reservoir parameters include the CAP_MIN minimum
+  # storage column and are provided as netcdf, parquet, and csv.
+  # files on this record are not served over plain http, so they are fetched through a
+  # signed S3 access point using anonymous credentials; no MSD-LIVE account is needed.
+  # see mosartwmpy/utilities/msdlive.py
   description: Sample input dataset that can be used for testing and development; covers 1980 - 1985.
-  url: https://data.msdlive.org/records/m6pp5-7xt54/files/mosartwmpy_sample_input_data_1980_1985.zip?download=1
+  url: https://data.msdlive.org/records/m28qs-54544
+  filename: mosartwmpy_sample_input_data_1980_1985.zip
   destination: ./
 
 validation:

--- a/mosartwmpy/grid/grid.py
+++ b/mosartwmpy/grid/grid.py
@@ -73,6 +73,7 @@ class Grid:
     reservoir_length: np.ndarray = np.empty(0)
     reservoir_surface_area: np.ndarray = np.empty(0)
     reservoir_storage_capacity: np.ndarray = np.empty(0)
+    reservoir_minimum_storage: np.ndarray = np.empty(0)
     reservoir_depth: np.ndarray = np.empty(0)
     reservoir_use_irrigation: np.ndarray = np.empty(0)
     reservoir_use_electricity: np.ndarray = np.empty(0)

--- a/mosartwmpy/grid/grid.py
+++ b/mosartwmpy/grid/grid.py
@@ -523,7 +523,7 @@ class Grid:
         # recreate the numba grid to reservoir map
         if grid.reservoir_dependency_database.size > 0:
             for grid_cell_id, group in grid.reservoir_dependency_database.reset_index().groupby('grid_cell_id'):
-                grid.grid_index_to_reservoirs_map[grid_cell_id] = group.reservoir_id.values
+                grid.grid_index_to_reservoirs_map[grid_cell_id] = group.reservoir_id.values.copy()
         
         return grid
 

--- a/mosartwmpy/reservoirs/grid.py
+++ b/mosartwmpy/reservoirs/grid.py
@@ -79,7 +79,7 @@ def load_reservoirs(self, config: Benedict, parameters: Parameters) -> None:
         value_type=types.int64[:],
     )
     for grid_cell_id, group in self.reservoir_dependency_database.groupby('grid_cell_id'):
-        self.grid_index_to_reservoirs_map[grid_cell_id] = group.reservoir_id.values
+        self.grid_index_to_reservoirs_map[grid_cell_id] = group.reservoir_id.values.copy()
 
     # index by grid cell
     self.reservoir_dependency_database = self.reservoir_dependency_database.set_index('grid_cell_id').sort_index()

--- a/mosartwmpy/reservoirs/grid.py
+++ b/mosartwmpy/reservoirs/grid.py
@@ -4,6 +4,7 @@ import xarray as xr
 
 from numba.core import types
 from numba.typed import Dict
+from pathlib import Path
 from xarray import concat, open_dataset, DataArray
 from benedict.dicts import benedict as Benedict
 
@@ -18,15 +19,23 @@ def load_reservoirs(self, config: Benedict, parameters: Parameters) -> None:
         parameters (Parameters): the model parameters
     """
 
-    # reservoir parameter file
-    reservoirs_file = open_dataset(config.get('water_management.reservoirs.parameters.path'))
+    # reservoir parameter file — supports .nc (netCDF), .parquet, or .csv
+    reservoir_path = config.get('water_management.reservoirs.parameters.path')
+    suffix = Path(reservoir_path).suffix.lower()
+    if suffix in ('.parquet',):
+        reservoir_df = pd.read_parquet(reservoir_path)
+    elif suffix in ('.csv',):
+        reservoir_df = pd.read_csv(reservoir_path)
+    else:
+        reservoirs_file = open_dataset(reservoir_path)
+        reservoir_df = reservoirs_file.to_dataframe()
+        reservoirs_file.close()
     reservoirs = pd.DataFrame(index=self.id).merge(
-        reservoirs_file.to_dataframe(),
+        reservoir_df,
         how='left',
         left_index=True,
         right_on=config.get('water_management.reservoirs.parameters.grid_cell_index'),
     )
-    reservoirs_file.close()
 
     # load reservoir variables
     # coerce to numpy arrays: under pandas with pyarrow, string columns (e.g. the
@@ -41,6 +50,16 @@ def load_reservoirs(self, config: Benedict, parameters: Parameters) -> None:
     self.reservoir_surface_area = self.reservoir_surface_area * 1.0e6
     # capacity from millions m^3 to m^3
     self.reservoir_storage_capacity = self.reservoir_storage_capacity * 1.0e6
+
+    # minimum storage: use CAP_MIN [million m3] from the file when present,
+    # otherwise fall back to reservoir_runoff_capacity_parameter * storage_capacity
+    cap_min_col = config.get('water_management.reservoirs.parameters.minimum_storage_variable', 'CAP_MIN')
+    if cap_min_col in reservoirs.columns and reservoirs[cap_min_col].notna().any():
+        cap_min_m3 = np.asarray(reservoirs[cap_min_col].values, dtype=np.float64) * 1.0e6
+        fallback = parameters.reservoir_runoff_capacity_parameter * self.reservoir_storage_capacity
+        self.reservoir_minimum_storage = np.where(np.isfinite(cap_min_m3), cap_min_m3, fallback)
+    else:
+        self.reservoir_minimum_storage = parameters.reservoir_runoff_capacity_parameter * self.reservoir_storage_capacity
 
     # reservoir dependency database file
     self.reservoir_dependency_database = pd.read_parquet(

--- a/mosartwmpy/reservoirs/regulation.py
+++ b/mosartwmpy/reservoirs/regulation.py
@@ -8,7 +8,7 @@ from numba.typed import List, Dict
 @nb.jit(
     "void("
         "int64, float64,"
-        "int64[:], float64[:], float64[:], float64[:],"
+        "int64[:], float64[:], float64[:], float64[:], float64[:],"
         "boolean[:], float64[:], float64[:], float64[:], float64[:], float64[:], float64"
     ")",
     nopython=True,
@@ -22,6 +22,7 @@ def regulation(
     reservoir_id,
     reservoir_surface_area,
     reservoir_storage_capacity,
+    reservoir_minimum_storage,
     euler_mask,
     channel_outflow_downstream,
     reservoir_release,
@@ -43,7 +44,7 @@ def regulation(
             evaporation = 1e6 * reservoir_potential_evaporation[i] * delta_t * reservoir_surface_area[i]
 
             minimum_flow = reservoir_runoff_capacity_parameter * reservoir_mean_inflow[i] * delta_t
-            minimum_storage = reservoir_runoff_capacity_parameter * reservoir_storage_capacity[i]
+            minimum_storage = reservoir_minimum_storage[i]
             maximum_storage = reservoir_storage_capacity[i]
 
             has_excess_storage = (inflow_volume + reservoir_storage[i] - outflow_volume - evaporation) >= maximum_storage

--- a/mosartwmpy/reservoirs/state.py
+++ b/mosartwmpy/reservoirs/state.py
@@ -34,7 +34,7 @@ def _load_initial_storage(grid: Grid, config: Benedict, default_storage: np.ndar
     """Loads per-reservoir initial storage from an optional file, falling back to default for missing values.
 
     The file (csv or parquet) must contain a CAP_INIT column [million m3] and at least one of:
-    GRAND_ID, GRID_CELL_INDEX, or RES_NAME as a join key. Matching is attempted in that priority order.
+    GRAND_ID or GRID_CELL_INDEX as a join key. Matching is attempted in that priority order.
     Reservoirs not matched in the file use default_storage.
     """
     init_path = config.get('water_management.reservoirs.initial_storage.path')
@@ -68,24 +68,42 @@ def _load_initial_storage(grid: Grid, config: Benedict, default_storage: np.ndar
     for join_key, grid_attr in [
         (res_id_col, 'reservoir_id'),
         (grid_idx_col, 'reservoir_grid_index'),
-        ('RES_NAME', None),
     ]:
         if join_key not in df.columns:
             continue
         grid_vals = getattr(grid, grid_attr, None) if grid_attr else None
         if grid_vals is None:
             continue
-        lookup = df.dropna(subset=[join_key, 'CAP_INIT']).set_index(join_key)['CAP_INIT']
+
+        deduped = df.dropna(subset=[join_key, 'CAP_INIT'])
+        n_dupes = deduped.duplicated(subset=[join_key]).sum()
+        if n_dupes:
+            logger.warning(
+                '%d duplicate "%s" value(s) in initial storage file — keeping last occurrence',
+                n_dupes, join_key,
+            )
+            deduped = deduped.drop_duplicates(subset=[join_key], keep='last')
+
+        lookup = deduped.set_index(join_key)['CAP_INIT']
         matched = pd.Series(grid_vals).map(lookup)
         valid = matched.notna().values
-        if valid.any():
-            storage[valid] = matched[valid].values.astype(np.float64) * 1.0e6
-            missing = (~valid).sum()
-            if missing:
-                logger.info(
-                    '%d reservoir(s) not matched in initial storage file — using default (0.9 * capacity)',
-                    missing,
-                )
+
+        if not valid.any():
+            logger.info(
+                'Identifier column "%s" present but matched no reservoirs — trying next identifier',
+                join_key,
+            )
+            continue
+
+        storage[valid] = matched[valid].values.astype(np.float64) * 1.0e6
+
+        is_reservoir = np.isfinite(np.asarray(grid_vals, dtype=np.float64))
+        missing = int((is_reservoir & ~valid).sum())
+        if missing:
+            logger.info(
+                '%d reservoir(s) not matched in initial storage file — using default (0.9 * capacity)',
+                missing,
+            )
         break
     else:
         logger.warning(

--- a/mosartwmpy/reservoirs/state.py
+++ b/mosartwmpy/reservoirs/state.py
@@ -1,9 +1,14 @@
+import logging
 import numpy as np
+import pandas as pd
 
+from pathlib import Path
 from benedict.dicts import benedict as Benedict
 
 from mosartwmpy.config.parameters import Parameters
 from mosartwmpy.grid.grid import Grid
+
+logger = logging.getLogger(__name__)
 
 
 def initialize_reservoir_state(self, grid: Grid, config: Benedict, parameters: Parameters) -> None:
@@ -18,10 +23,77 @@ def initialize_reservoir_state(self, grid: Grid, config: Benedict, parameters: P
     # reservoir storage at the start of the operation year
     self.reservoir_storage_operation_year_start = 0.85 * grid.reservoir_storage_capacity
 
-    # initial storage in each reservoir
-    self.reservoir_storage = 0.9 * grid.reservoir_storage_capacity
+    # initial storage in each reservoir — default to 90% of capacity
+    default_storage = 0.9 * grid.reservoir_storage_capacity
+    self.reservoir_storage = _load_initial_storage(grid, config, default_storage)
 
     initialize_reservoir_start_of_operation_year(self, grid, config, parameters)
+
+
+def _load_initial_storage(grid: Grid, config: Benedict, default_storage: np.ndarray) -> np.ndarray:
+    """Loads per-reservoir initial storage from an optional file, falling back to default for missing values.
+
+    The file (csv or parquet) must contain a CAP_INIT column [million m3] and at least one of:
+    GRAND_ID, GRID_CELL_INDEX, or RES_NAME as a join key. Matching is attempted in that priority order.
+    Reservoirs not matched in the file use default_storage.
+    """
+    init_path = config.get('water_management.reservoirs.initial_storage.path')
+    if not init_path:
+        return default_storage
+
+    path = Path(init_path)
+    if not path.exists():
+        logger.warning('Reservoir initial storage file not found: %s — using default (0.9 * capacity)', init_path)
+        return default_storage
+
+    suffix = path.suffix.lower()
+    if suffix == '.parquet':
+        df = pd.read_parquet(path)
+    elif suffix == '.csv':
+        df = pd.read_csv(path)
+    else:
+        logger.warning('Unsupported initial storage file format "%s" — using default (0.9 * capacity)', suffix)
+        return default_storage
+
+    if 'CAP_INIT' not in df.columns:
+        logger.warning('CAP_INIT column missing from initial storage file — using default (0.9 * capacity)')
+        return default_storage
+
+    # build a Series indexed by grid position, matching on the first available identifier
+    res_id_col = config.get('water_management.reservoirs.parameters.variables.reservoir_id', 'GRAND_ID')
+    grid_idx_col = config.get('water_management.reservoirs.parameters.grid_cell_index', 'GRID_CELL_INDEX')
+
+    storage = default_storage.copy()
+
+    for join_key, grid_attr in [
+        (res_id_col, 'reservoir_id'),
+        (grid_idx_col, 'reservoir_grid_index'),
+        ('RES_NAME', None),
+    ]:
+        if join_key not in df.columns:
+            continue
+        grid_vals = getattr(grid, grid_attr, None) if grid_attr else None
+        if grid_vals is None:
+            continue
+        lookup = df.dropna(subset=[join_key, 'CAP_INIT']).set_index(join_key)['CAP_INIT']
+        matched = pd.Series(grid_vals).map(lookup)
+        valid = matched.notna().values
+        if valid.any():
+            storage[valid] = matched[valid].values.astype(np.float64) * 1.0e6
+            missing = (~valid).sum()
+            if missing:
+                logger.info(
+                    '%d reservoir(s) not matched in initial storage file — using default (0.9 * capacity)',
+                    missing,
+                )
+        break
+    else:
+        logger.warning(
+            'No usable identifier column (%s, %s, RES_NAME) found in initial storage file — using default',
+            res_id_col, grid_idx_col,
+        )
+
+    return storage
 
 
 def initialize_reservoir_start_of_operation_year(self, grid: Grid, config: Benedict, parameters: Parameters) -> None:

--- a/mosartwmpy/tests/test_msdlive.py
+++ b/mosartwmpy/tests/test_msdlive.py
@@ -1,0 +1,234 @@
+import io
+import unittest
+import zipfile
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from mosartwmpy.utilities import msdlive
+from mosartwmpy.utilities.download_data import InstallSupplement
+
+
+# the placeholder is listed first, as S3 returns keys in lexical order, so picking
+# the first entry rather than the archive would silently download 12 bytes
+LIST_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>msdlive-project-im3</Name>
+  <Prefix>abcde-12345/</Prefix>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>abcde-12345/dummy.txt</Key>
+    <Size>12</Size>
+  </Contents>
+  <Contents>
+    <Key>abcde-12345/sample_data.zip</Key>
+    <Size>702662166</Size>
+  </Contents>
+</ListBucketResult>
+"""
+
+CREDENTIALS = {
+    'region': 'us-west-2',
+    'accountId': '889772541283',
+    'credentials': {
+        'accessKeyId': 'ASIAEXAMPLE',
+        'secretKey': 'secret',
+        'sessionToken': 'token',
+        'expiration': 0,
+    },
+}
+
+
+class FakeResponse:
+    """Stand-in for a requests.Response."""
+
+    def __init__(self, text='', content=b'', status_code=200):
+        self.text = text
+        self._content = content
+        self.status_code = status_code
+        self.headers = {'content-length': str(len(content))}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise AssertionError(f'status {self.status_code}')
+
+    def iter_content(self, chunk_size=1):
+        for i in range(0, len(self._content), chunk_size):
+            yield self._content[i:i + chunk_size]
+
+
+class RecordUrlTest(unittest.TestCase):
+    """Test recognizing MSD-LIVE record urls."""
+
+    MSDLIVE_URLS = [
+        'https://data.msdlive.org/records/m28qs-54544',
+        'https://data.msdlive.org/records/m28qs-54544/files/a.zip?download=1',
+        'https://data.msdlive.org/api/records/m6pp5-7xt54/files/a.zip/content',
+    ]
+
+    OTHER_URLS = [
+        'https://zenodo.org/record/6959736/files/mosartwmpy_tutorial_1981_05.zip?download=1',
+        'https://zenodo.org/record/5609702/files/mosartwmpy_validation.zip?download=1',
+        'https://example.com/data.zip',
+    ]
+
+    def test_recognizes_record_urls(self):
+        for url in self.MSDLIVE_URLS:
+            self.assertTrue(msdlive.is_msdlive_record_url(url), url)
+
+    def test_ignores_other_urls(self):
+        for url in self.OTHER_URLS:
+            self.assertFalse(msdlive.is_msdlive_record_url(url), url)
+
+    def test_ignores_none(self):
+        self.assertFalse(msdlive.is_msdlive_record_url(None))
+
+    def test_extracts_record_id(self):
+        self.assertEqual(msdlive.record_id_from_url(self.MSDLIVE_URLS[0]), 'm28qs-54544')
+        self.assertEqual(msdlive.record_id_from_url(self.MSDLIVE_URLS[1]), 'm28qs-54544')
+        self.assertEqual(msdlive.record_id_from_url(self.MSDLIVE_URLS[2]), 'm6pp5-7xt54')
+
+    def test_raises_without_record_id(self):
+        with self.assertRaises(ValueError):
+            msdlive.record_id_from_url('https://zenodo.org/record/6959736/files/a.zip')
+
+
+class SignedRequestTest(unittest.TestCase):
+    """Test the SigV4 signing, without contacting AWS."""
+
+    def signed(self, **kwargs):
+        with patch.object(msdlive.requests, 'request', return_value=FakeResponse()) as mock:
+            msdlive._signed_request(CREDENTIALS, 'abcde-12345', **kwargs)
+        return mock.call_args
+
+    def test_targets_the_record_access_point(self):
+        args, kwargs = self.signed(key='abcde-12345/sample_data.zip')
+        self.assertEqual(
+            args[1],
+            'https://abcde-12345-889772541283.s3-accesspoint.us-west-2.amazonaws.com'
+            '/abcde-12345/sample_data.zip',
+        )
+
+    def test_sends_required_headers(self):
+        _, kwargs = self.signed(key='abcde-12345/sample_data.zip')
+        headers = kwargs['headers']
+        self.assertEqual(headers['x-amz-security-token'], 'token')
+        self.assertEqual(headers['x-amz-content-sha256'], msdlive.UNSIGNED_PAYLOAD)
+        self.assertIn('x-amz-date', headers)
+        self.assertTrue(headers['Authorization'].startswith(msdlive.ALGORITHM))
+        self.assertIn('Credential=ASIAEXAMPLE/', headers['Authorization'])
+        # every signed header must be declared, and only signed headers may be listed
+        self.assertIn(
+            'SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token',
+            headers['Authorization'],
+        )
+
+    def test_extra_headers_are_passed_through(self):
+        _, kwargs = self.signed(key='a/b.zip', headers={'Range': 'bytes=0-3'})
+        self.assertEqual(kwargs['headers']['Range'], 'bytes=0-3')
+
+    def test_query_is_sorted_into_the_url(self):
+        args, _ = self.signed(query={'prefix': 'abcde-12345/', 'list-type': '2'})
+        # canonical query must be sorted, so list-type precedes prefix
+        self.assertIn('?list-type=2&prefix=abcde-12345%2F', args[1])
+
+    def test_signature_changes_with_the_key(self):
+        _, one = self.signed(key='a/one.zip')
+        _, two = self.signed(key='a/two.zip')
+        self.assertNotEqual(one['headers']['Authorization'], two['headers']['Authorization'])
+
+
+class FindArchiveTest(unittest.TestCase):
+    """Test choosing which file in a record to download."""
+
+    def setUp(self):
+        patcher = patch.object(msdlive, '_signed_request', return_value=FakeResponse(text=LIST_RESPONSE))
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_lists_files_largest_first(self):
+        files = msdlive.list_record_files('abcde-12345', credentials=CREDENTIALS)
+        self.assertEqual([f['size'] for f in files], [702662166, 12])
+
+    def test_prefers_the_zip_over_the_placeholder(self):
+        archive = msdlive.find_archive('abcde-12345', credentials=CREDENTIALS)
+        self.assertEqual(archive['key'], 'abcde-12345/sample_data.zip')
+        self.assertEqual(archive['size'], 702662166)
+
+    def test_selects_by_extension_not_by_size(self):
+        """A large non-archive must not be chosen over a smaller zip.
+
+        Guards the case that matters: these records pair the real payload with a
+        placeholder file, and picking on size alone would break if the placeholder
+        ever grew.
+        """
+
+        listing = LIST_RESPONSE.replace('<Size>12</Size>', '<Size>999999999999</Size>')
+        with patch.object(msdlive, '_signed_request', return_value=FakeResponse(text=listing)):
+            archive = msdlive.find_archive('abcde-12345', credentials=CREDENTIALS)
+        self.assertEqual(archive['key'], 'abcde-12345/sample_data.zip')
+
+    def test_honors_an_explicit_filename(self):
+        archive = msdlive.find_archive('abcde-12345', filename='dummy.txt', credentials=CREDENTIALS)
+        self.assertEqual(archive['key'], 'abcde-12345/dummy.txt')
+
+    def test_raises_for_a_missing_filename(self):
+        with self.assertRaises(FileNotFoundError):
+            msdlive.find_archive('abcde-12345', filename='absent.zip', credentials=CREDENTIALS)
+
+
+class FindArchiveWithoutZipTest(unittest.TestCase):
+    """A record holding no archive should raise rather than return the placeholder."""
+
+    NO_ZIP = LIST_RESPONSE.replace('sample_data.zip', 'sample_data.tar')
+
+    def test_raises_without_a_zip(self):
+        with patch.object(msdlive, '_signed_request', return_value=FakeResponse(text=self.NO_ZIP)):
+            with self.assertRaises(FileNotFoundError):
+                msdlive.find_archive('abcde-12345', credentials=CREDENTIALS)
+
+
+class DownloadRoutingTest(unittest.TestCase):
+    """Test that InstallSupplement routes each url to the right transport."""
+
+    @staticmethod
+    def zip_bytes():
+        stream = io.BytesIO()
+        with zipfile.ZipFile(stream, 'w') as zipped:
+            zipped.writestr('input/hello.txt', 'hello')
+        return stream.getvalue()
+
+    def test_msdlive_url_uses_the_signed_path(self):
+        with TemporaryDirectory() as tmpdir:
+            supplement = InstallSupplement(
+                url='https://data.msdlive.org/records/abcde-12345',
+                destination=tmpdir,
+                filename='sample_data.zip',
+            )
+            with patch.object(msdlive, 'get_anonymous_credentials', return_value=CREDENTIALS), \
+                 patch.object(msdlive, '_signed_request') as signed:
+                signed.side_effect = [
+                    FakeResponse(text=LIST_RESPONSE),          # list
+                    FakeResponse(content=self.zip_bytes()),    # download
+                ]
+                supplement.fetch()
+            self.assertTrue((Path(tmpdir) / 'input' / 'hello.txt').is_file())
+
+    def test_plain_url_uses_requests(self):
+        with TemporaryDirectory() as tmpdir:
+            supplement = InstallSupplement(
+                url='https://zenodo.org/record/1/files/a.zip?download=1',
+                destination=tmpdir,
+            )
+            with patch(
+                'mosartwmpy.utilities.download_data.requests.get',
+                return_value=FakeResponse(content=self.zip_bytes()),
+            ) as get:
+                supplement.fetch()
+            get.assert_called_once()
+            self.assertTrue((Path(tmpdir) / 'input' / 'hello.txt').is_file())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mosartwmpy/tests/test_reservoir_parameters.py
+++ b/mosartwmpy/tests/test_reservoir_parameters.py
@@ -1,0 +1,260 @@
+import numpy as np
+import pandas as pd
+import unittest
+import yaml
+
+import importlib.resources
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from xarray import open_dataset
+
+from benedict.dicts import benedict as Benedict
+
+from mosartwmpy.config.parameters import Parameters
+from mosartwmpy.grid.grid import Grid
+from mosartwmpy.reservoirs.grid import load_reservoirs
+from mosartwmpy.reservoirs.state import _load_initial_storage
+
+
+class ReservoirParametersTest(unittest.TestCase):
+    """Test the reservoir parameter file formats, minimum storage, and initial storage."""
+
+    # package data
+    DEFAULTS_FILE = str(importlib.resources.files('mosartwmpy').joinpath('config_defaults.yaml'))
+    RESERVOIRS_FILE = str(importlib.resources.files('mosartwmpy').joinpath('tests', 'reservoirs.nc'))
+    DEPENDENCIES_FILE = str(importlib.resources.files('mosartwmpy').joinpath('tests', 'dependency_database.parquet'))
+    FLOW_FILE = str(importlib.resources.files('mosartwmpy').joinpath('tests', 'mean_flow.parquet'))
+    DEMAND_FILE = str(importlib.resources.files('mosartwmpy').joinpath('tests', 'mean_demand.parquet'))
+
+    # the sample reservoir file covers a grid larger than the reservoir count
+    GRID_SIZE = 20000
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = TemporaryDirectory()
+        base = Path(cls.tmpdir.name)
+
+        # the bundled sample file predates the minimum storage field, so build the
+        # variants used by these tests from it, adding CAP_MIN where needed
+        with open_dataset(cls.RESERVOIRS_FILE) as ds:
+            frame = ds.to_dataframe()
+
+        cls.no_cap_min_path = str(base / 'reservoirs_no_cap_min.nc')
+        frame.to_xarray().to_netcdf(cls.no_cap_min_path)
+
+        with_cap_min = frame.copy()
+        with_cap_min['CAP_MIN'] = 0.25 * with_cap_min['CAP_MCM']
+
+        cls.paths_with_cap_min = {
+            '.nc': str(base / 'reservoirs.nc'),
+            '.csv': str(base / 'reservoirs.csv'),
+            '.parquet': str(base / 'reservoirs.parquet'),
+        }
+        with_cap_min.to_xarray().to_netcdf(cls.paths_with_cap_min['.nc'])
+        with_cap_min.to_csv(cls.paths_with_cap_min['.csv'], index=False)
+        with_cap_min.to_parquet(cls.paths_with_cap_min['.parquet'], index=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmpdir.cleanup()
+
+    def make_config(self, reservoir_path):
+        """Builds a config from the packaged defaults, pointed at the test reservoir files."""
+        with open(self.DEFAULTS_FILE) as file:
+            config = Benedict(yaml.safe_load(file))
+        config['water_management.reservoirs.parameters.path'] = reservoir_path
+        config['water_management.reservoirs.dependencies.path'] = self.DEPENDENCIES_FILE
+        config['water_management.reservoirs.streamflow.path'] = self.FLOW_FILE
+        config['water_management.reservoirs.demand.path'] = self.DEMAND_FILE
+        return config
+
+    def load(self, reservoir_path):
+        """Loads reservoirs onto an otherwise empty grid."""
+        grid = Grid(empty=True)
+        grid.id = np.arange(self.GRID_SIZE)
+        load_reservoirs(grid, self.make_config(reservoir_path), Parameters())
+        return grid
+
+    def test_file_formats_are_equivalent(self):
+        """netCDF, csv, and parquet reservoir files should produce an identical grid."""
+
+        grids = {suffix: self.load(path) for suffix, path in self.paths_with_cap_min.items()}
+        reference = grids['.nc']
+
+        # the reservoir arrays that come straight from the parameter file
+        keys = [
+            key for key in self.make_config(
+                self.paths_with_cap_min['.nc']
+            ).get('water_management.reservoirs.parameters.variables').keys()
+        ] + ['reservoir_minimum_storage']
+
+        for suffix, grid in grids.items():
+            if suffix == '.nc':
+                continue
+            for key in keys:
+                expected = getattr(reference, key)
+                actual = getattr(grid, key)
+                self.assertEqual(expected.shape, actual.shape, f'{key} shape differs for {suffix}')
+                if np.issubdtype(expected.dtype, np.number):
+                    np.testing.assert_allclose(
+                        actual.astype(np.float64),
+                        expected.astype(np.float64),
+                        equal_nan=True,
+                        err_msg=f'{key} differs for {suffix}',
+                    )
+                else:
+                    # object/string columns, compared with nulls normalized
+                    self.assertTrue(
+                        pd.Series(actual).astype('object').equals(pd.Series(expected).astype('object')),
+                        f'{key} differs for {suffix}',
+                    )
+
+    def test_minimum_storage_read_from_file(self):
+        """CAP_MIN in the parameter file should set the minimum storage, converted to m3."""
+
+        grid = self.load(self.paths_with_cap_min['.nc'])
+        is_reservoir = np.isfinite(grid.reservoir_storage_capacity) & (grid.reservoir_storage_capacity > 0)
+
+        self.assertGreater(is_reservoir.sum(), 0, 'sample data contains reservoirs')
+        # CAP_MIN was written as 0.25 * CAP_MCM, and both are scaled from million m3 to m3
+        np.testing.assert_allclose(
+            grid.reservoir_minimum_storage[is_reservoir],
+            0.25 * grid.reservoir_storage_capacity[is_reservoir],
+        )
+
+    def test_minimum_storage_falls_back_without_cap_min(self):
+        """A parameter file with no CAP_MIN column should fall back to the historical default."""
+
+        grid = self.load(self.no_cap_min_path)
+        is_reservoir = np.isfinite(grid.reservoir_storage_capacity) & (grid.reservoir_storage_capacity > 0)
+
+        self.assertGreater(is_reservoir.sum(), 0, 'sample data contains reservoirs')
+        np.testing.assert_allclose(
+            grid.reservoir_minimum_storage[is_reservoir],
+            Parameters().reservoir_runoff_capacity_parameter * grid.reservoir_storage_capacity[is_reservoir],
+        )
+
+    def test_minimum_storage_falls_back_per_reservoir(self):
+        """Reservoirs with a missing CAP_MIN value should fall back individually."""
+
+        with open_dataset(self.paths_with_cap_min['.nc']) as ds:
+            frame = ds.to_dataframe()
+        # blank out CAP_MIN for a few reservoirs that land on the test grid
+        on_grid = frame[frame['GRID_CELL_INDEX'].between(0, self.GRID_SIZE - 1)]
+        blanked_ids = on_grid['GRAND_ID'].values[:5]
+        frame.loc[frame['GRAND_ID'].isin(blanked_ids), 'CAP_MIN'] = np.nan
+        path = str(Path(self.tmpdir.name) / 'reservoirs_partial_cap_min.csv')
+        frame.to_csv(path, index=False)
+
+        grid = self.load(path)
+        blanked = np.isin(grid.reservoir_id, blanked_ids)
+        capacity = grid.reservoir_storage_capacity
+
+        self.assertGreater(blanked.sum(), 0, 'blanked reservoirs are present on the grid')
+        np.testing.assert_allclose(
+            grid.reservoir_minimum_storage[blanked],
+            Parameters().reservoir_runoff_capacity_parameter * capacity[blanked],
+        )
+
+        supplied = np.isfinite(capacity) & (capacity > 0) & ~blanked
+        np.testing.assert_allclose(
+            grid.reservoir_minimum_storage[supplied],
+            0.25 * capacity[supplied],
+        )
+
+    def test_minimum_storage_is_declared_on_grid(self):
+        """The field must exist on a grid loaded from cache, which skips load_reservoirs."""
+
+        self.assertTrue(hasattr(Grid(empty=True), 'reservoir_minimum_storage'))
+
+
+class InitialStorageTest(unittest.TestCase):
+    """Test the optional initial reservoir storage file."""
+
+    def setUp(self):
+        self.tmpdir = TemporaryDirectory()
+        self.grid = Grid(empty=True)
+        # a realistic grid: mostly non-reservoir cells, NaN padded
+        self.grid.reservoir_id = np.array([np.nan, 7.0, np.nan, 9.0])
+        self.grid.reservoir_grid_index = np.array([np.nan, 1.0, np.nan, 3.0])
+        self.default = np.array([1.0e6, 2.0e6, 3.0e6, 4.0e6])
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def make_config(self, path):
+        return Benedict({'water_management': {'reservoirs': {
+            'initial_storage': {'path': path},
+            'parameters': {
+                'grid_cell_index': 'GRID_CELL_INDEX',
+                'variables': {'reservoir_id': 'GRAND_ID'},
+            },
+        }}})
+
+    def write(self, frame, name='initial_storage.csv'):
+        path = str(Path(self.tmpdir.name) / name)
+        if name.endswith('.parquet'):
+            frame.to_parquet(path, index=False)
+        else:
+            frame.to_csv(path, index=False)
+        return path
+
+    def load(self, path):
+        return _load_initial_storage(self.grid, self.make_config(path), self.default.copy())
+
+    def test_no_path_returns_default(self):
+        self.assertIs(_load_initial_storage(self.grid, self.make_config(None), self.default), self.default)
+
+    def test_missing_file_returns_default(self):
+        path = str(Path(self.tmpdir.name) / 'absent.csv')
+        np.testing.assert_array_equal(self.load(path), self.default)
+
+    def test_matches_on_reservoir_id(self):
+        """CAP_INIT is in million m3 and applies only to matched reservoirs."""
+
+        path = self.write(pd.DataFrame({'GRAND_ID': [7], 'CAP_INIT': [50.0]}))
+        np.testing.assert_allclose(self.load(path), [1.0e6, 50.0e6, 3.0e6, 4.0e6])
+
+    def test_matches_from_parquet(self):
+        path = self.write(pd.DataFrame({'GRAND_ID': [7], 'CAP_INIT': [50.0]}), 'initial_storage.parquet')
+        np.testing.assert_allclose(self.load(path), [1.0e6, 50.0e6, 3.0e6, 4.0e6])
+
+    def test_falls_through_to_grid_cell_index(self):
+        """A present-but-unmatched identifier should not stop the search."""
+
+        path = self.write(pd.DataFrame({
+            'GRAND_ID': [999], 'GRID_CELL_INDEX': [3], 'CAP_INIT': [77.0],
+        }))
+        np.testing.assert_allclose(self.load(path), [1.0e6, 2.0e6, 3.0e6, 77.0e6])
+
+    def test_duplicate_identifiers_keep_last(self):
+        """Duplicate ids should be tolerated rather than raising."""
+
+        path = self.write(pd.DataFrame({'GRAND_ID': [7, 7], 'CAP_INIT': [50.0, 60.0]}))
+        np.testing.assert_allclose(self.load(path), [1.0e6, 60.0e6, 3.0e6, 4.0e6])
+
+    def test_no_overlap_returns_default(self):
+        path = self.write(pd.DataFrame({'GRAND_ID': [999], 'CAP_INIT': [77.0]}))
+        np.testing.assert_array_equal(self.load(path), self.default)
+
+    def test_missing_cap_init_column_returns_default(self):
+        path = self.write(pd.DataFrame({'GRAND_ID': [7], 'STORAGE': [50.0]}))
+        np.testing.assert_array_equal(self.load(path), self.default)
+
+    def test_unsupported_format_returns_default(self):
+        path = str(Path(self.tmpdir.name) / 'initial_storage.txt')
+        Path(path).write_text('GRAND_ID,CAP_INIT\n7,50.0\n')
+        np.testing.assert_array_equal(self.load(path), self.default)
+
+    def test_does_not_mutate_default(self):
+        """The caller's default array must not be modified in place."""
+
+        path = self.write(pd.DataFrame({'GRAND_ID': [7], 'CAP_INIT': [50.0]}))
+        default = self.default.copy()
+        _load_initial_storage(self.grid, self.make_config(path), default)
+        np.testing.assert_array_equal(default, self.default)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mosartwmpy/update/update.py
+++ b/mosartwmpy/update/update.py
@@ -242,6 +242,7 @@ def update(state: State, grid: Grid, parameters: Parameters, config: Benedict, c
                     grid.reservoir_id,
                     grid.reservoir_surface_area,
                     grid.reservoir_storage_capacity,
+                    grid.reservoir_minimum_storage,
                     state.euler_mask,
                     state.channel_outflow_downstream,
                     state.reservoir_release,

--- a/mosartwmpy/utilities/CREATE_GRAND_PARAMETERS.md
+++ b/mosartwmpy/utilities/CREATE_GRAND_PARAMETERS.md
@@ -1,7 +1,7 @@
 ## create_grand_parameters.py
 
 This utility method generates the four dam/reservoir related input files expected by `mosartwmpy`:
-* `grand_reservoir_parameters.nc` - dam/reservoir physical and behavioral parameters
+* `grand_reservoir_parameters.nc` - dam/reservoir physical and behavioral parameters (also writable as `.parquet` or `.csv` by changing the output file extension)
 * `grand_average_monthly_flow.parquet` - mean monthly flow across the reservoir during the expected simulation period
 * `grand_average_monthly_demand.parquet` - mean monthly demand on the reservoir's water during the expected simulation period
 * `grand_dependency_database.parquet` - mapping between GRanD ID and grid cell IDs allowed to extract water
@@ -16,6 +16,13 @@ Several datasets are required to perform this operation:
 
 Note that the reservoir parameters and dependency database provided in the tutorial are reasonably robust for a 1/8 degree grid --
 for most use cases it would be sufficient to simply update the mean flow and demand files as appropriate to your simulation.
+
+### minimum storage
+
+The reservoir parameter file includes a `CAP_MIN` column holding the minimum (dead) storage in million m<sup>3</sup>,
+written as `--minimum-storage-fraction` (default `0.1`) times `CAP_MCM`.
+GRanD ships a field of the same name meaning a lower bound estimate of the reported *total* capacity, which is not what
+`mosartwmpy` expects here, so this utility overwrites it. Adjust individual values afterward where better information is available.
 
 Once the necessary data has been collected, run the utility with the `create_grand_parameters` that is installed along with `mosartwmpy`.
 This script will ask for the locations of the datasets and desired output locations.

--- a/mosartwmpy/utilities/create_grand_parameters.py
+++ b/mosartwmpy/utilities/create_grand_parameters.py
@@ -2,6 +2,7 @@ import click
 import numpy as np
 import pandas as pd
 import geopandas as gpd
+from pathlib import Path
 from shapely.geometry import Point
 import xarray as xr
 from scipy.spatial import KDTree
@@ -139,6 +140,12 @@ from scipy.spatial import KDTree
     ),
     prompt='What is the path to a CSV file containing reservoir placement corrections? Leave blank for none'
 )
+@click.option(
+    '--minimum-storage-fraction',
+    default=0.1,
+    type=click.FloatRange(min=0, max=1),
+    help="""Fraction of storage capacity to write as the minimum (dead) storage CAP_MIN."""
+)
 def create_grand_parameters(
         grid_path,
         grand_path,
@@ -168,6 +175,7 @@ def create_grand_parameters(
         dependency_radius_meters=200000,
         corrections_grid_index_key='gindex',
         corrections_grand_id_key='GRAND_ID',
+        minimum_storage_fraction=0.1,
         istarf_key_map=dict(
             GRanD_MEANFLOW_CUMECS='grand_meanflow_cumecs',
             Obs_MEANFLOW_CUMECS='observed_meanflow_cumecs',
@@ -551,12 +559,26 @@ def create_grand_parameters(
         right_on='GRanD_ID',
     )
 
-    # write reservoir parameters to file
-    filtered[
+    # minimum (dead) storage, as a fraction of storage capacity [million m3]
+    # note this deliberately overwrites the GRanD field of the same name, which is a lower bound
+    # estimate of the reported total capacity rather than the dead storage mosartwmpy expects;
+    # adjust individual values afterward where better information is available
+    filtered['CAP_MIN'] = minimum_storage_fraction * filtered['CAP_MCM']
+
+    # write reservoir parameters to file; the model accepts netcdf, parquet, or csv,
+    # chosen here by the extension of the requested output path
+    reservoir_parameters = filtered[
         ['GRAND_ID', 'GRID_CELL_INDEX', 'RES_NAME', 'DAM_NAME', 'RIVER', 'YEAR', 'DAM_HGT_M', 'DAM_LEN_M', 'AREA_SKM',
-         'CAP_MCM', 'DEPTH_M', 'CATCH_SKM', 'USE_IRRI', 'USE_ELEC', 'USE_SUPP', 'USE_FCON', 'USE_RECR', 'USE_NAVI',
-         'USE_FISH', 'USE_PCON', 'USE_OTHR', 'MAIN_USE', 'ORIGINAL_GRID_CELL_INDEX', 'LONG_DD',
-         'LAT_DD'] + list(istarf_key_map.values())].to_xarray().to_netcdf(reservoir_output_path)
+         'CAP_MCM', 'CAP_MIN', 'DEPTH_M', 'CATCH_SKM', 'USE_IRRI', 'USE_ELEC', 'USE_SUPP', 'USE_FCON', 'USE_RECR',
+         'USE_NAVI', 'USE_FISH', 'USE_PCON', 'USE_OTHR', 'MAIN_USE', 'ORIGINAL_GRID_CELL_INDEX', 'LONG_DD',
+         'LAT_DD'] + list(istarf_key_map.values())]
+    reservoir_suffix = Path(reservoir_output_path).suffix.lower()
+    if reservoir_suffix == '.parquet':
+        reservoir_parameters.to_parquet(reservoir_output_path, index=False)
+    elif reservoir_suffix == '.csv':
+        reservoir_parameters.to_csv(reservoir_output_path, index=False)
+    else:
+        reservoir_parameters.to_xarray().to_netcdf(reservoir_output_path)
 
     # write dependency database to file
     dependency_database.to_parquet(dependency_output_path)

--- a/mosartwmpy/utilities/download_data.py
+++ b/mosartwmpy/utilities/download_data.py
@@ -10,6 +10,14 @@ import zipfile
 
 from benedict import benedict
 
+from mosartwmpy.utilities.msdlive import (
+    find_archive,
+    is_msdlive_record_url,
+    get_anonymous_credentials,
+    open_record_file_stream,
+    record_id_from_url,
+)
+
 
 def download_data(dataset: str, destination: str = None, manifest: str = str(importlib.resources.files('mosartwmpy').joinpath('data_manifest.yaml'))) -> None:
     """Convenience wrapper for the InstallSupplement class.
@@ -30,9 +38,10 @@ def download_data(dataset: str, destination: str = None, manifest: str = str(imp
 
     get = InstallSupplement(
         url=data_dictionary.get(f'{dataset}.url'),
-        destination=destination if destination is not None else Path(data_dictionary.get(f'{dataset}.destination', './'))
+        destination=destination if destination is not None else Path(data_dictionary.get(f'{dataset}.destination', './')),
+        filename=data_dictionary.get(f'{dataset}.filename'),
     )
-    get.fetch_zenodo()
+    get.fetch()
 
 
 class InstallSupplement:
@@ -45,11 +54,12 @@ class InstallSupplement:
 
     """
 
-    def __init__(self, url, destination):
+    def __init__(self, url, destination, filename=None):
 
         self.initialize_logger()
         self.destination = self.valid_directory(destination)
         self.url = url
+        self.filename = filename
 
     def initialize_logger(self):
         """Initialize logger to stdout."""
@@ -88,37 +98,92 @@ class InstallSupplement:
             self.close_logger()
             raise NotADirectoryError(msg)
 
+    def fetch(self):
+        """Download and unpack the example data supplement for the current distribution.
+
+        Datasets hosted on MSD-LIVE record urls are fetched through a signed S3 access
+        point, since those files are not served over plain HTTP; everything else is
+        downloaded directly.
+        """
+
+        if is_msdlive_record_url(self.url):
+            self.fetch_msdlive()
+        else:
+            self.fetch_zenodo()
+
     def fetch_zenodo(self):
-        """Download and unpack the Zenodo example data supplement for the
-        current distribution."""
+        """Download and unpack an example data supplement served over plain HTTP."""
 
         # retrieve content from URL
         try:
             logging.info(f"Downloading example data from {self.url}")
             r = requests.get(self.url, stream=True)
-            with io.BytesIO() as stream:
-                with tqdm.wrapattr(
-                    stream,
-                    'write',
-                    file=sys.stdout,
-                    miniters=1,
-                    desc=self.url,
-                    total=int(r.headers.get('content-length', 0))
-                ) as file:
-                    for chunk in r.iter_content(chunk_size=4096):
-                        file.write(chunk)
-                with zipfile.ZipFile(stream) as zipped:
-                    # extract each file in the zipped dir to the project
-                    for f in zipped.namelist():
-                        logging.info("Unzipped: {}".format(os.path.join(self.destination, f)))
-                        zipped.extract(f, self.destination)
-
-            logging.info("Download and install complete.")
-
-            self.close_logger()
+            self._unpack(
+                chunks=r.iter_content(chunk_size=4096),
+                total=int(r.headers.get('content-length', 0)),
+                description=self.url,
+            )
 
         except requests.exceptions.MissingSchema:
             msg = f"Unable to download data from {self.url}"
             logging.exception(msg)
             self.close_logger()
             raise
+
+    def fetch_msdlive(self):
+        """Download and unpack an example data supplement from a MSD-LIVE record.
+
+        Files on newer MSD-LIVE records are not reachable over plain HTTP, so this
+        requests anonymous read only credentials and signs a request against the
+        record's S3 access point. No MSD-LIVE account is required.
+        """
+
+        try:
+            record_id = record_id_from_url(self.url)
+            logging.info(f"Downloading example data from MSD-LIVE record {record_id}")
+
+            credentials = get_anonymous_credentials()
+            archive = find_archive(record_id, filename=self.filename, credentials=credentials)
+            response = open_record_file_stream(record_id, archive['key'], credentials=credentials)
+
+            self._unpack(
+                chunks=response.iter_content(chunk_size=1024 * 1024),
+                total=archive['size'],
+                description=archive['key'].rsplit('/', 1)[-1],
+            )
+
+        except (requests.exceptions.RequestException, FileNotFoundError, ValueError, KeyError):
+            msg = f"Unable to download data from {self.url}"
+            logging.exception(msg)
+            self.close_logger()
+            raise
+
+    def _unpack(self, chunks, total, description):
+        """Buffer a zip archive from an iterator of chunks and extract it to the destination.
+
+        Args:
+            chunks (iterable): iterator yielding bytes of the archive
+            total (int): expected size in bytes, for the progress bar
+            description (str): label for the progress bar
+        """
+
+        with io.BytesIO() as stream:
+            with tqdm.wrapattr(
+                stream,
+                'write',
+                file=sys.stdout,
+                miniters=1,
+                desc=description,
+                total=total,
+            ) as file:
+                for chunk in chunks:
+                    file.write(chunk)
+            with zipfile.ZipFile(stream) as zipped:
+                # extract each file in the zipped dir to the project
+                for f in zipped.namelist():
+                    logging.info("Unzipped: {}".format(os.path.join(self.destination, f)))
+                    zipped.extract(f, self.destination)
+
+        logging.info("Download and install complete.")
+
+        self.close_logger()

--- a/mosartwmpy/utilities/msdlive.py
+++ b/mosartwmpy/utilities/msdlive.py
@@ -1,0 +1,287 @@
+"""Fetch public MSD-LIVE datasets that are not served over plain HTTP.
+
+MSD-LIVE records created from July 2023 onward store their files in a
+project-owned S3 bucket reached through a per-record access point, rather than in
+InvenioRDM's managed storage. For those records the Invenio file API reports only
+a small placeholder file and ``/api/records/<id>/files/<name>/content`` returns
+404, so there is no URL a plain HTTP client can fetch. Older records are
+unaffected and are still downloaded directly by ``download_data``.
+
+The data is public: a credentials endpoint hands out short lived, read only AWS
+credentials to anonymous callers, which are then used to sign requests against
+the record's access point. No account or login is involved.
+
+Requests are signed with AWS Signature Version 4 using only ``requests`` and the
+standard library, to avoid adding a ``boto3`` dependency for this one code path.
+"""
+
+import datetime
+import hashlib
+import hmac
+import logging
+import re
+import urllib.parse
+import xml.etree.ElementTree as ElementTree
+
+import requests
+
+# hands out anonymous, read only credentials scoped to public records
+CREDENTIALS_URL = 'https://data.msdlive.org/api/get-aws-credentials'
+
+# recognize a MSD-LIVE record page or api url and pull out the record id
+RECORD_ID_PATTERN = re.compile(r'data\.msdlive\.org/(?:api/)?records/([a-z0-9]+-[a-z0-9]+)', re.IGNORECASE)
+
+S3_NAMESPACE = {'s3': 'http://s3.amazonaws.com/doc/2006-03-01/'}
+
+ALGORITHM = 'AWS4-HMAC-SHA256'
+# the access point rejects a payload hash for streamed reads; this is the documented sentinel
+UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD'
+
+
+def is_msdlive_record_url(url: str) -> bool:
+    """Whether a url points at a MSD-LIVE record.
+
+    Args:
+        url (str): the url to inspect
+
+    Returns:
+        bool: True if a record id can be read out of the url
+    """
+
+    return url is not None and RECORD_ID_PATTERN.search(url) is not None
+
+
+def record_id_from_url(url: str) -> str:
+    """Extract the record id from a MSD-LIVE record url.
+
+    Args:
+        url (str): a record page or api url, optionally including a file path
+
+    Returns:
+        str: the record id, i.e. the ``m28qs-54544`` in a record url
+
+    Raises:
+        ValueError: if no record id is present in the url
+    """
+
+    match = RECORD_ID_PATTERN.search(url or '')
+    if not match:
+        raise ValueError(f'Unable to find a MSD-LIVE record id in "{url}".')
+    return match.group(1)
+
+
+def get_anonymous_credentials(credentials_url: str = CREDENTIALS_URL) -> dict:
+    """Request short lived, read only AWS credentials for public records.
+
+    Args:
+        credentials_url (str): endpoint handing out the credentials
+
+    Returns:
+        dict: the parsed response, with ``region``, ``accountId`` and ``credentials`` keys
+    """
+
+    response = requests.get(credentials_url, timeout=60)
+    response.raise_for_status()
+    payload = response.json()
+    for key in ('region', 'accountId', 'credentials'):
+        if key not in payload:
+            raise KeyError(f'MSD-LIVE credentials response is missing "{key}".')
+    return payload
+
+
+def _sign(key: bytes, message: str) -> bytes:
+    """HMAC-SHA256 one step of the SigV4 key derivation chain."""
+
+    return hmac.new(key, message.encode('utf-8'), hashlib.sha256).digest()
+
+
+def _signing_key(secret_key: str, datestamp: str, region: str) -> bytes:
+    """Derive the SigV4 signing key for S3 in a region on a date."""
+
+    key = _sign(f'AWS4{secret_key}'.encode('utf-8'), datestamp)
+    key = _sign(key, region)
+    key = _sign(key, 's3')
+    return _sign(key, 'aws4_request')
+
+
+def _signed_request(
+    credentials: dict,
+    record_id: str,
+    method: str = 'GET',
+    key: str = '',
+    query: dict = None,
+    headers: dict = None,
+    stream: bool = False,
+) -> requests.Response:
+    """Send a SigV4 signed request to a record's S3 access point.
+
+    Args:
+        credentials (dict): as returned by ``get_anonymous_credentials``
+        record_id (str): the MSD-LIVE record id, which names the access point
+        method (str): HTTP method
+        key (str): object key within the access point, or empty to address the root
+        query (dict): query parameters, used for listing
+        headers (dict): extra request headers, i.e. a Range header
+        stream (bool): whether to stream the response body
+
+    Returns:
+        requests.Response: the response, with status left for the caller to check
+    """
+
+    region = credentials['region']
+    account_id = credentials['accountId']
+    session = credentials['credentials']
+
+    host = f'{record_id}-{account_id}.s3-accesspoint.{region}.amazonaws.com'
+    canonical_uri = '/' + urllib.parse.quote(key, safe='/~')
+
+    # S3 requires the canonical query string to be sorted and rfc3986 encoded
+    query = query or {}
+    canonical_query = '&'.join(
+        f'{urllib.parse.quote(k, safe="~")}={urllib.parse.quote(str(v), safe="~")}'
+        for k, v in sorted(query.items())
+    )
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    amzdate = now.strftime('%Y%m%dT%H%M%SZ')
+    datestamp = now.strftime('%Y%m%d')
+
+    # only these headers are signed; anything else the caller adds is not
+    signed = {
+        'host': host,
+        'x-amz-content-sha256': UNSIGNED_PAYLOAD,
+        'x-amz-date': amzdate,
+        'x-amz-security-token': session['sessionToken'],
+    }
+    signed_header_names = ';'.join(sorted(signed))
+    canonical_headers = ''.join(f'{name}:{signed[name]}\n' for name in sorted(signed))
+
+    canonical_request = '\n'.join([
+        method,
+        canonical_uri,
+        canonical_query,
+        canonical_headers,
+        signed_header_names,
+        UNSIGNED_PAYLOAD,
+    ])
+
+    scope = f'{datestamp}/{region}/s3/aws4_request'
+    string_to_sign = '\n'.join([
+        ALGORITHM,
+        amzdate,
+        scope,
+        hashlib.sha256(canonical_request.encode('utf-8')).hexdigest(),
+    ])
+
+    signature = hmac.new(
+        _signing_key(session['secretKey'], datestamp, region),
+        string_to_sign.encode('utf-8'),
+        hashlib.sha256,
+    ).hexdigest()
+
+    request_headers = dict(signed)
+    request_headers['Authorization'] = (
+        f'{ALGORITHM} Credential={session["accessKeyId"]}/{scope}, '
+        f'SignedHeaders={signed_header_names}, Signature={signature}'
+    )
+    if headers:
+        request_headers.update(headers)
+
+    url = f'https://{host}{canonical_uri}'
+    if canonical_query:
+        url = f'{url}?{canonical_query}'
+
+    return requests.request(method, url, headers=request_headers, stream=stream, timeout=120)
+
+
+def list_record_files(record_id: str, credentials: dict = None) -> list:
+    """List the files available in a public MSD-LIVE record.
+
+    Args:
+        record_id (str): the MSD-LIVE record id
+        credentials (dict): reuse existing credentials, otherwise fetched
+
+    Returns:
+        list: dicts with ``key`` and ``size``, sorted largest first
+    """
+
+    credentials = credentials or get_anonymous_credentials()
+
+    files = []
+    continuation_token = None
+    while True:
+        query = {'list-type': '2', 'prefix': f'{record_id}/'}
+        if continuation_token:
+            query['continuation-token'] = continuation_token
+        response = _signed_request(credentials, record_id, query=query)
+        response.raise_for_status()
+
+        tree = ElementTree.fromstring(response.text)
+        for contents in tree.findall('s3:Contents', S3_NAMESPACE):
+            key = contents.find('s3:Key', S3_NAMESPACE).text
+            size = int(contents.find('s3:Size', S3_NAMESPACE).text)
+            files.append({'key': key, 'size': size})
+
+        truncated = tree.find('s3:IsTruncated', S3_NAMESPACE)
+        if truncated is not None and truncated.text == 'true':
+            token = tree.find('s3:NextContinuationToken', S3_NAMESPACE)
+            continuation_token = token.text if token is not None else None
+            if continuation_token:
+                continue
+        break
+
+    return sorted(files, key=lambda f: f['size'], reverse=True)
+
+
+def find_archive(record_id: str, filename: str = None, credentials: dict = None) -> dict:
+    """Choose which file in a record to download.
+
+    Args:
+        record_id (str): the MSD-LIVE record id
+        filename (str): a specific file to look for, otherwise the largest zip is used
+        credentials (dict): reuse existing credentials, otherwise fetched
+
+    Returns:
+        dict: the chosen file, with ``key`` and ``size``
+
+    Raises:
+        FileNotFoundError: if the record has no matching file
+    """
+
+    credentials = credentials or get_anonymous_credentials()
+    files = list_record_files(record_id, credentials=credentials)
+
+    if filename:
+        for entry in files:
+            if entry['key'].rsplit('/', 1)[-1] == filename:
+                return entry
+        raise FileNotFoundError(f'MSD-LIVE record {record_id} has no file named "{filename}".')
+
+    # records carry a small placeholder file alongside the real payload, so prefer
+    # the largest zip rather than simply the first entry
+    archives = [entry for entry in files if entry['key'].lower().endswith('.zip')]
+    if not archives:
+        raise FileNotFoundError(
+            f'MSD-LIVE record {record_id} contains no zip archive; found '
+            f'{[entry["key"] for entry in files]}.'
+        )
+    return archives[0]
+
+
+def open_record_file_stream(record_id: str, key: str, credentials: dict = None) -> requests.Response:
+    """Open a streaming response for a file in a public MSD-LIVE record.
+
+    Args:
+        record_id (str): the MSD-LIVE record id
+        key (str): the full object key within the access point
+        credentials (dict): reuse existing credentials, otherwise fetched
+
+    Returns:
+        requests.Response: a streaming response positioned at the start of the file
+    """
+
+    credentials = credentials or get_anonymous_credentials()
+    logging.debug(f'Requesting {key} from MSD-LIVE record {record_id}.')
+    response = _signed_request(credentials, record_id, key=key, stream=True)
+    response.raise_for_status()
+    return response


### PR DESCRIPTION
Supersedes #123. Carries @danbroman's three commits unchanged (same SHAs, his authorship intact) plus two follow-up commits from review.

Opened as a new branch rather than pushing to `danbroman:min-res-storage` so the fixes could land without writing to his fork.

## What this adds

All three features are opt-in and backward compatible.

- **Per-reservoir minimum storage.** An optional `CAP_MIN` column (million m<sup>3</sup>, like `CAP_MCM`) sets the storage below which a reservoir will not release, replacing the hardcoded 10% of capacity in `regulation()`. Configurable via `water_management.reservoirs.parameters.minimum_storage_variable`. Reservoirs with no value, and files with no such column, fall back to the previous 10%.
- **Parquet and CSV reservoir parameter files.** That file holds static per-reservoir values with a single dimension, so netCDF was never necessary. Format is chosen by extension.
- **Optional initial reservoir storage.** `initial_storage.path` accepts Parquet or CSV with a `CAP_INIT` column, joined on `GRAND_ID` or `GRID_CELL_INDEX`. Unmatched reservoirs fall back to 90% of capacity.

Also fixes a latent numba issue: `grid_index_to_reservoirs_map` values are now `.copy()`d, since numba `int64[:]` typed dicts need owned contiguous arrays and a pandas groupby view can be non-contiguous.

## Follow-up commits in this PR

**Config key placement.** `reservoir_minimum_storage: CAP_MIN` had been added to the `parameters.variables` block. `load_reservoirs` iterates that block and indexes every mapped column unconditionally, so any reservoir file without a `CAP_MIN` column raised `KeyError: 'CAP_MIN'` — including the currently published sample data. That also made the per-value fallback ten lines below unreachable. Moved to `parameters.minimum_storage_variable`, which is the key the code actually reads and was previously undocumented.

**Tests** (`mosartwmpy/tests/test_reservoir_parameters.py`, 15 cases; suite 9 → 24). Covers format equivalence across `.nc`/`.csv`/`.parquet`, minimum storage (from file, whole-file fallback, per-reservoir fallback, `Grid` declaration), and initial storage (both join keys, duplicate ids, fallthrough, unsupported format, no mutation of the caller's array).

These were mutation-tested rather than just run green. Re-adding the bad config entry fails `test_minimum_storage_falls_back_without_cap_min`; deleting the `Grid` dataclass field fails `test_minimum_storage_is_declared_on_grid`. Both bugs found during review are now caught — the existing suite missed them because it loads a cached `grid.zip` via `Grid.from_files()`, which bypasses `load_reservoirs` entirely.

**`create_grand_parameters`** now emits `CAP_MIN` as `--minimum-storage-fraction` (default `0.1`) times `CAP_MCM`, and writes whichever of the three formats the output path names. GRanD ships a `CAP_MIN` field meaning a lower bound estimate of *total* reported capacity rather than dead storage, and `gpd.read_file` loads every GRanD column, so it would otherwise leak through — the utility deliberately overwrites it.

**Docs.** README sections for the three features, CHANGELOG entries, and `CREATE_GRAND_PARAMETERS.md` notes on the `CAP_MIN` derivation and the GRanD name collision.

## Before releasing v1.0.0

The published sample input data predates `CAP_MIN`, so the feature can't be exercised against the downloadable inputs until a new data package goes up. Flagged in `RELEASING.md` and as a `TODO` on the `sample_input` entry in `data_manifest.yaml`. The `sample_input` URL points at record `m6pp5-7xt54` (v0.0.6), already behind `syt0j-x0203` (v0.0.7). Without `CAP_MIN` the model still runs and falls back to 10% of capacity, so this blocks feature verification rather than the release.

## Known limitation

ISTARF release rules derive their Normal Operating Range from storage capacity alone and do not respect `CAP_MIN`. Left as-is deliberately; tracked in #124 with @danbroman's assessment of what incorporating it would take.

## Testing

`pytest mosartwmpy/tests/` — 24 passed. Verified separately that a legacy reservoir file without `CAP_MIN` falls back to exactly `0.1 × capacity`, and that all three formats produce identical `reservoir_minimum_storage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)