### PR TITLE
Update Dockerfile to a maintained base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-# syntax=docker/dockerfile:1
-FROM python:3.9-slim-bullseye
-WORKDIR /app
-COPY README.md README.md
-COPY setup.cfg setup.cfg
-COPY setup.py setup.py
-COPY mosartwmpy mosartwmpy
-RUN pip3 install -e .
-VOLUME /data
-WORKDIR /data
-CMD [ "python3", "-c" , "from mosartwmpy import Model; m = Model(); m.initialize('config.yaml'); m.update_until();"]
+# To test this container locally, run:
+# docker build -t mosartwmpy .
+# docker run --rm -p 8888:8888 mosartwmpy
+
+FROM ghcr.io/msd-live/jupyter/python-notebook:dev
+
+USER root
+
+# Give permissions to jovyan to write to the matplotlib directory.
+RUN mkdir -p /home/jovyan/.config/matplotlib && \
+chmod 777 -R /home/jovyan/.config/matplotlib
+
+# Install mosartwmpy
+RUN pip install --upgrade pip
+RUN pip install mosartwmpy
+
+# Install tutorial data.
+RUN python -c "from mosartwmpy.utilities.download_data import download_data; download_data('tutorial');"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,8 @@
 # docker build -t mosartwmpy .
 # docker run --rm -p 8888:8888 mosartwmpy
 
-FROM ghcr.io/msd-live/jupyter/python-notebook:dev
-
-USER root
-
-# Give permissions to jovyan to write to the matplotlib directory.
-RUN mkdir -p /home/jovyan/.config/matplotlib && \
-chmod 777 -R /home/jovyan/.config/matplotlib
+FROM ghcr.io/msd-live/jupyter/python-notebook:latest
 
 # Install mosartwmpy
 RUN pip install --upgrade pip
 RUN pip install mosartwmpy
-
-# Install tutorial data.
-RUN python -c "from mosartwmpy.utilities.download_data import download_data; download_data('tutorial');"


### PR DESCRIPTION
Merges @erexer's Dockerfile work from January 2025, which had been sitting on `hotfix/dockerfile` unmerged. Opening this to get that work credited and on the record rather than deleting the branch during release cleanup.

It also fixes a real problem in passing. The Dockerfile currently on `release/1.0.0` is:

```dockerfile
FROM python:3.9-slim-bullseye
...
RUN pip3 install -e .
```

Python 3.9 no longer satisfies `python_requires>=3.10`, raised by the numpy 2 migration in this release, so `pip3 install -e .` fails and the image cannot build at all. This branch replaces the base with `ghcr.io/msd-live/jupyter/python-notebook:latest`, which I confirmed is pullable and carries Python 3.11.

Two commits, both @erexer:

- `49f242e` update dockerfile to use new base image
- `463c3e4` remove downloading data

### Notes

The new form installs from PyPI (`pip install mosartwmpy`) rather than the local checkout, so the image tracks the published release rather than the source tree it was built from. That is right for a user-facing MSD-LIVE notebook image and wrong for testing local changes. Flagging it rather than changing it, since the MSD-LIVE base image implies the former was the intent.

Nothing in the repo references the Dockerfile: not the JOSS paper (`paper/paper.md` has no mention of docker or containers), not the README, not the docs, and no workflow builds it. That is why the stale Python pin went unnoticed, and it also means this change is low risk.

Merges cleanly; `release/1.0.0` has not touched the Dockerfile since the merge base.